### PR TITLE
Run upstream Argo Rollouts E2E tests on argo-rollouts-manager PRs (#30)

### DIFF
--- a/.github/workflows/rollouts_e2e_tests.yml
+++ b/.github/workflows/rollouts_e2e_tests.yml
@@ -1,0 +1,49 @@
+name: Run upstream Argo-Rollouts E2E tests
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release-*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+
+  test-e2e:
+    name: Run end-to-end tests from upstream Argo Rollouts repo
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k3s-version: [ v1.28.2 ]
+        # k3s-version: [ v1.28.2, v1.27.6, v1.26.9 ]
+    steps:
+      - name: Install K3S
+        run: |
+          set -x
+          curl -sfL https://get.k3s.io | sh -
+          sudo chmod -R a+rw /etc/rancher/k3s
+          sudo mkdir -p $HOME/.kube && sudo chown -R runner $HOME/.kube
+          sudo k3s kubectl config view --raw > $HOME/.kube/config
+          sudo chown runner $HOME/.kube/config
+          sudo chmod go-r $HOME/.kube/config
+          kubectl version
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.21
+      - name: GH actions workaround - Kill XSP4 process
+        run: |
+          sudo pkill mono || true
+      - name: Add /usr/local/bin to PATH
+        run: |
+          echo "/usr/local/bin" >> $GITHUB_PATH
+      - name: Download Go dependencies
+        run: |
+          go mod download
+      - name: Run the Argo Rollouts E2E tests
+        run: |
+          set -o pipefail
+          ./hack/run-upstream-argo-rollouts-e2e-tests.sh

--- a/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
@@ -102,6 +102,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - apisix.apache.org
+          resources:
+          - apisixroutes
+          verbs:
+          - get
+          - update
+          - watch
+        - apiGroups:
           - appmesh.k8s.aws
           resources:
           - virtualnodes

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apisix.apache.org
+  resources:
+  - apisixroutes
+  verbs:
+  - get
+  - update
+  - watch
+- apiGroups:
   - appmesh.k8s.aws
   resources:
   - virtualnodes

--- a/controllers/argorollouts_controller.go
+++ b/controllers/argorollouts_controller.go
@@ -69,6 +69,7 @@ var log = logr.Log.WithName("rollouts-controller")
 //+kubebuilder:rbac:groups="split.smi-spec.io",resources=trafficsplits,verbs=create;watch;get;update;patch
 //+kubebuilder:rbac:groups="traefik.containo.us",resources=traefikservices,verbs=watch;get;update
 //+kubebuilder:rbac:groups="x.getambassador.io",resources=ambassadormappings;mappings,verbs=create;watch;get;update;list;delete
+//+kubebuilder:rbac:groups="apisix.apache.org",resources=apisixroutes,verbs=watch;get;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -717,6 +717,19 @@ func GetPolicyRules() []rbacv1.PolicyRule {
 				"update",
 			},
 		},
+		{
+			APIGroups: []string{
+				"apisix.apache.org",
+			},
+			Resources: []string{
+				"apisixroutes",
+			},
+			Verbs: []string{
+				"watch",
+				"get",
+				"update",
+			},
+		},
 	}
 }
 

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+CURRENT_ROLLOUTS_VERSION=v1.6.4
+
+function cleanup {
+  echo "* Cleaning up"
+	killall main
+  killall go
+}
+
+set -x
+set -e
+
+trap cleanup EXIT
+
+# Directory of bash script
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# 1) Clone a specific version of argo-rollouts into a temporary directory
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+cd $TMP_DIR
+
+git clone https://github.com/argoproj/argo-rollouts
+cd argo-rollouts
+git checkout $CURRENT_ROLLOUTS_VERSION
+go mod tidy
+
+# 2) Setup the Namespace
+
+kubectl delete ns argo-rollouts || true
+
+kubectl wait --timeout=5m --for=delete namespace/argo-rollouts 
+
+kubectl create ns argo-rollouts
+kubectl config set-context --current --namespace=argo-rollouts
+
+
+# 3) Build, install, and start the argo-rollouts-manager controller
+cd $SCRIPT_DIR/..
+make generate fmt vet install
+
+set +e
+
+rm -f /tmp/e2e-operator-run.log || true
+go run ./main.go 2>&1 | tee /tmp/e2e-operator-run.log &
+
+set -e
+
+# 4) Install Argo Rollouts into the Namespace via RolloutManater CR
+
+cd $TMP_DIR/argo-rollouts
+
+cat << EOF > $TMP_DIR/rollout-manager.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: RolloutManager
+metadata:
+  name: argo-rollout
+spec:
+  extraCommandArgs:
+    - "--loglevel" 
+    - "debug" 
+    - "--kloglevel" 
+    - "6"
+    - "--instance-id"
+    - "argo-rollouts-e2e"
+EOF
+
+kubectl apply -f $TMP_DIR/rollout-manager.yaml
+
+echo "* Waiting for Argo Rollouts Deployment to exist"
+
+until kubectl get -n argo-rollouts deployment/argo-rollouts
+do
+  sleep 1s
+done
+
+kubectl wait --for=condition=Available --timeout=10m -n argo-rollouts deployment/argo-rollouts
+
+kubectl apply -f test/e2e/crds
+
+# Required because the rollouts containers run as root, and OpenShift's default security policy doesn't like that
+oc adm policy add-scc-to-user anyuid -z argo-rollouts -n argo-rollouts || true
+oc adm policy add-scc-to-user anyuid -z default -n argo-rollouts || true
+
+
+# 5) Run the E2E tests
+rm -f /tmp/test-e2e.log
+
+set +e
+
+make test-e2e | tee /tmp/test-e2e.log
+
+set +x
+
+# 6) Check the results for unexpected failures
+
+# Here we grep out the failures we expect, as of January 2024:
+# - Most of these tests fail 100% of the time, because they were not designed to run against Argo Rollouts running on a cluster. (These are safe to ignore.)
+#     - The rollouts tests are written to assume they are running locally: not within a container, and not on a K8s cluster.
+# - Some are intermittently failing, implying a race condition in the test/product.
+# - Finally, some still need to be investigated, to determine why they are failing in this case.
+UNEXPECTED_FAILURES=`cat /tmp/test-e2e.log | grep "FAIL:" | grep -v "re-run" \
+  | grep -v "TestAPISIXSuite (" \
+  | grep -v "TestFunctionalSuite (" \
+  | grep -v "TestCanarySuite (" \
+  | grep -v "TestAWSSuite (" \
+  | grep -v "TestExperimentSuite (" \
+  | grep -v "TestControllerMetrics" \
+  | grep -v "TestAPISIXCanarySetHeaderStep" \
+  | grep -v "TestALBExperimentStep " \
+  | grep -v "TestALBExperimentStepNoSetWeightMultiIngress"  \
+  | grep -v "TestCanaryDynamicStableScale"  \
+  | grep -v "TestExperimentWithDryRunMetrics" \
+  | grep -v "TestBlueGreenPromoteFull" \
+  | grep -v "TestALBExperimentStepNoSetWeight" \
+  | grep -v "TestCanaryScaleDownOnAbort"`
+
+# As of January 2024 (Rollouts v1.6.4):
+# 
+# Always fail:
+# - TestCanaryDynamicStableScale
+# - TestCanaryScaleDownOnAbort
+# - TestAPISIXCanarySetHeaderStep
+# - TestControllerMetrics (also fails when running upstream rollouts as a container)
+# - TestExperimentWithDryRunMetrics (also fails when running upstream rollouts as a container)
+#
+# Intermittently fail:
+# - TestBlueGreenPromoteFull
+# - TestALBExperimentStepNoSetWeight
+# - TestALBExperimentStep
+# - TestALBExperimentStepNoSetWeightMultiIngress
+
+echo "-----------------------------------------------------------------"
+echo
+echo "These were the tests that succeeded:"
+echo
+cat /tmp/test-e2e.log | grep "PASS" | sort
+echo
+echo "These were the tests that failed:"
+echo
+cat /tmp/test-e2e.log | grep "    --- FAIL:" | grep -v "re-run" | sort -u
+echo
+echo
+
+if [ -n "$UNEXPECTED_FAILURES" ]; then
+  echo "* FAIL: Unexpected failures occurred."
+  exit 1
+else
+  echo "* SUCCESS: No unexpected errors occurred."
+fi


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Contributes a shell script which automatically clones argo-rollouts, and runs the E2E tests against the repo
- Adds a new GitHub workflow to run the above script
- Fixes a missing test CR, apisix, which needs to be added for the test to pass

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
Fixes #30

**How to test changes / Special notes to the reviewer**: N/A
