### PR TITLE
Add new e2e tests

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -146,7 +146,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToAdminClusterRole(
 			Name: name,
 		},
 	}
-	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name)
+	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name, aggregationType)
 
 	if err := fetchObject(ctx, r.Client, cr.Namespace, clusterRole.Name, clusterRole); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -180,7 +180,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToEditClusterRole(c
 			Name: name,
 		},
 	}
-	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name)
+	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name, aggregationType)
 
 	if err := fetchObject(ctx, r.Client, cr.Namespace, clusterRole.Name, clusterRole); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -214,7 +214,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToViewClusterRole(c
 			Name: name,
 		},
 	}
-	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name)
+	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name, aggregationType)
 
 	if err := fetchObject(ctx, r.Client, cr.Namespace, clusterRole.Name, clusterRole); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -395,13 +395,13 @@ func (r *RolloutManagerReconciler) deleteRolloutResources(ctx context.Context, c
 	return nil
 }
 
-func setRolloutsAggregatedClusterRoleLabels(obj *metav1.ObjectMeta, name string) {
+func setRolloutsAggregatedClusterRoleLabels(obj *metav1.ObjectMeta, name string, aggregationType string) {
 
 	obj.Labels = map[string]string{}
 	obj.Labels["app.kubernetes.io/component"] = "aggregate-cluster-role"
 	obj.Labels["app.kubernetes.io/name"] = name
 	obj.Labels["app.kubernetes.io/part-of"] = DefaultArgoRolloutsResourceName
-	obj.Labels["rbac.authorization.k8s.io/aggregate-to-admin"] = "true"
+	obj.Labels["rbac.authorization.k8s.io/"+aggregationType] = "true"
 }
 
 // getPolicyRules returns the policy rules for Argo Rollouts Role.

--- a/tests/e2e/rollouts_test.go
+++ b/tests/e2e/rollouts_test.go
@@ -26,68 +26,106 @@ var _ = Describe("RolloutManager tests", func() {
 	Context("RolloutManager tests", func() {
 
 		var (
-			k8sClient client.Client
-			ctx       context.Context
+			k8sClient      client.Client
+			ctx            context.Context
+			rolloutManager rolloutsmanagerv1alpha1.RolloutManager
 		)
 
+		BeforeEach(func() {
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+
+			var err error
+			k8sClient, err = fixture.GetE2ETestKubeClient()
+			Expect(err).ToNot(HaveOccurred())
+			ctx = context.Background()
+
+			rolloutManager = rolloutsmanagerv1alpha1.RolloutManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-rollouts-manager",
+					Namespace: fixture.TestE2ENamespace,
+				},
+				Spec: rolloutsmanagerv1alpha1.RolloutManagerSpec{},
+			}
+		})
+
 		When("Reconcile is called on a new, basic, namespaced-scoped RolloutManager", func() {
-
-			BeforeEach(func() {
-				Expect(fixture.EnsureCleanSlate()).To(Succeed())
-
-				var err error
-				k8sClient, err = fixture.GetE2ETestKubeClient()
-				Expect(err).ToNot(HaveOccurred())
-				ctx = context.Background()
-
-			})
-
 			It("should create the appropriate K8s resources", func() {
+				Expect(k8sClient.Create(ctx, &rolloutManager)).To(Succeed())
 
-				rolloutsManager := rolloutsmanagerv1alpha1.RolloutManager{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-rollouts-manager",
-						Namespace: fixture.TestE2ENamespace,
-					},
-					Spec: rolloutsmanagerv1alpha1.RolloutManagerSpec{},
+				By("setting the phase to \"Available\"")
+				Eventually(rolloutManager, "60s", "1s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
+
+				By("creating a service account")
+				sa := corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}
+				Eventually(&sa, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+
+				By("ensuring the service account has the correct labels")
+				ensureLabels(&sa.ObjectMeta)
+
+				By("creating a role")
+				role := rbacv1.Role{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}
+				Eventually(&role, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+
+				By("ensuring the role has the correct labels")
+				ensureLabels(&role.ObjectMeta)
+
+				By("ensuring the role has the correct policy rules")
+				Expect(role.Rules).To(ConsistOf(controllers.GetPolicyRules()))
+
+				By("creating a role binding")
+				binding := rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}
+				Eventually(&binding, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+
+				By("ensuring the role binding has the correct labels")
+				ensureLabels(&binding.ObjectMeta)
+
+				By("creating three cluster roles")
+				clusterRoleSuffixes := []string{"aggregate-to-admin", "aggregate-to-edit", "aggregate-to-view"}
+				for _, suffix := range clusterRoleSuffixes {
+					clusterRoleName := "argo-rollouts-" + suffix
+					clusterRole := rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
+					}
+					Eventually(&clusterRole, "30s", "1s").Should(k8s.ExistByName(k8sClient))
+
+					Expect(len(binding.Labels)).To(Equal(3))
+					Expect(clusterRole.Labels["app.kubernetes.io/name"]).To(Equal(clusterRoleName))
+					Expect(clusterRole.Labels["app.kubernetes.io/part-of"]).To(Equal(controllers.DefaultArgoRolloutsResourceName))
+					Expect(clusterRole.Labels["app.kubernetes.io/component"]).To(Equal("aggregate-cluster-role"))
+					Expect(clusterRole.Labels["rbac.authorization.k8s.io/"+suffix]).To(Equal("true"))
 				}
 
-				Expect(k8sClient.Create(ctx, &rolloutsManager)).To(Succeed())
-
-				Eventually(rolloutsManager, "60s", "1s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
-
-				Eventually(&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutsManager.Namespace},
-				}, "10s", "1s").Should(k8s.ExistByName(k8sClient))
-
-				Eventually(&rbacv1.Role{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutsManager.Namespace},
-				}, "10s", "1s").Should(k8s.ExistByName(k8sClient))
-
-				Eventually(&rbacv1.RoleBinding{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutsManager.Namespace},
-				}, "10s", "1s").Should(k8s.ExistByName(k8sClient))
-
-				clusterRoles := []string{"argo-rollouts-aggregate-to-admin", "argo-rollouts-aggregate-to-edit", "argo-rollouts-aggregate-to-view"}
-
-				for _, clusterRole := range clusterRoles {
-					Eventually(&rbacv1.ClusterRole{
-						ObjectMeta: metav1.ObjectMeta{Name: clusterRole},
-					}, "30s", "1s").Should(k8s.ExistByName(k8sClient))
+				By("creating a deployment")
+				deployment := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
 				}
+				Eventually(&deployment, "10s", "1s").Should(k8s.ExistByName(k8sClient))
 
-				Eventually(&appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutsManager.Namespace},
-				}, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+				By("ensuring the deployment has the correct labels")
+				ensureLabels(&deployment.ObjectMeta)
 
-				Eventually(&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsMetricsServiceName, Namespace: rolloutsManager.Namespace},
-				}, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+				By("creating a service")
+				service := corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsMetricsServiceName, Namespace: rolloutManager.Namespace},
+				}
+				Eventually(&service, "10s", "1s").Should(k8s.ExistByName(k8sClient))
 
+				By("ensuring the service has the correct labels")
+				Expect(service.Labels["app.kubernetes.io/name"]).To(Equal(controllers.DefaultArgoRolloutsMetricsServiceName))
+				Expect(service.Labels["app.kubernetes.io/part-of"]).To(Equal(controllers.DefaultArgoRolloutsResourceName))
+				Expect(service.Labels["app.kubernetes.io/component"]).To(Equal("server"))
+
+				By("having the deployment become ready")
 				Eventually(func() bool {
 
 					depl := appsv1.Deployment{
-						ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutsManager.Namespace},
+						ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
 					}
 					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&depl), &depl); err != nil {
 						return false
@@ -97,34 +135,170 @@ var _ = Describe("RolloutManager tests", func() {
 
 				}, "120s", "1s").Should(BeTrue())
 
+				By("creating a secret")
 				Eventually(&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultRolloutsNotificationSecretName, Namespace: rolloutsManager.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultRolloutsNotificationSecretName, Namespace: rolloutManager.Namespace},
 				}, "30s", "1s").Should(k8s.ExistByName(k8sClient))
-
 			})
+		})
 
-			It("should create a Role in the namespace containing all required RBAC permissions", func() {
+		When("A RolloutManager is deleted", func() {
+			It("should delete all the associated resources", func() {
+				Expect(k8sClient.Create(ctx, &rolloutManager)).To(Succeed())
+				Eventually(rolloutManager, "60s", "1s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
 
-				rolloutsManager := rolloutsmanagerv1alpha1.RolloutManager{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-rollouts-manager",
-						Namespace: fixture.TestE2ENamespace,
+				Expect(k8sClient.Delete(ctx, &rolloutManager)).To(Succeed())
+
+				By("deleting the service account")
+				Eventually(&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+
+				By("deleting the role")
+				Eventually(&rbacv1.Role{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+
+				By("deleting the role binding")
+				Eventually(&rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+
+				By("deleting the deployment")
+				Eventually(&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+
+				By("deleting the service")
+				Eventually(&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsMetricsServiceName, Namespace: rolloutManager.Namespace},
+				}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+
+				By("deleting the secret")
+				Eventually(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultRolloutsNotificationSecretName, Namespace: rolloutManager.Namespace},
+				}, "30s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+
+				// Make sure the cluster roles have not been deleted
+				By("NOT deleting the three cluster roles")
+				clusterRoleSuffixes := []string{"aggregate-to-admin", "aggregate-to-edit", "aggregate-to-view"}
+				for _, suffix := range clusterRoleSuffixes {
+					clusterRoleName := "argo-rollouts-" + suffix
+					Consistently(&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
+					}, "5s", "1s").Should(k8s.ExistByName(k8sClient))
+				}
+			})
+		})
+
+		When("A RolloutManager specifies an extra argument", func() {
+			It("should reflect that argument in the deployment", func() {
+				By("creating the deployment with the argument from the RolloutManager")
+				rolloutManager.Spec = rolloutsmanagerv1alpha1.RolloutManagerSpec{
+					ExtraCommandArgs: []string{
+						"--loglevel",
+						"error",
 					},
-					Spec: rolloutsmanagerv1alpha1.RolloutManagerSpec{},
 				}
-
-				Expect(k8sClient.Create(ctx, &rolloutsManager)).To(Succeed())
-
-				Eventually(rolloutsManager, "60s", "1s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
-
-				role := rbacv1.Role{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: fixture.TestE2ENamespace},
+				Expect(k8sClient.Create(ctx, &rolloutManager)).To(Succeed())
+				deployment := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
 				}
-				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&role), &role)).To(Succeed())
+				Eventually(&deployment, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(Equal([]string{"--namespaced", "--loglevel", "error"}))
 
-				Expect(role.Rules).To(ConsistOf(controllers.GetPolicyRules()))
+				By("updating the deployment when the argument in the RolloutManager is updated")
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&rolloutManager), &rolloutManager)).To(Succeed())
+				rolloutManager.Spec = rolloutsmanagerv1alpha1.RolloutManagerSpec{
+					ExtraCommandArgs: []string{
+						"--logformat",
+						"text",
+					},
+				}
+				Expect(k8sClient.Update(ctx, &rolloutManager)).To(Succeed())
+				Eventually(func() []string {
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment)).To(Succeed())
+					return deployment.Spec.Template.Spec.Containers[0].Args
+				}, "10s", "1s").Should(Equal([]string{"--namespaced", "--logformat", "text"}))
+			})
+		})
 
+		When("A RolloutManager specifies environment variables", func() {
+			It("should reflect those variables in the deployment", func() {
+				By("creating the deployment with the environment variables specified in the RolloutManager")
+				rolloutManager.Spec = rolloutsmanagerv1alpha1.RolloutManagerSpec{
+					Env: []corev1.EnvVar{
+						{Name: "EDITOR", Value: "emacs"},
+						{Name: "LANG", Value: "en_CA.UTF-8"},
+					},
+				}
+				Expect(k8sClient.Create(ctx, &rolloutManager)).To(Succeed())
+				deployment := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}
+				Eventually(&deployment, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+					corev1.EnvVar{Name: "EDITOR", Value: "emacs"},
+					corev1.EnvVar{Name: "LANG", Value: "en_CA.UTF-8"},
+				))
+
+				By("updating the deployment when the environment variables in the RolloutManager are updated")
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&rolloutManager), &rolloutManager)).To(Succeed())
+				rolloutManager.Spec = rolloutsmanagerv1alpha1.RolloutManagerSpec{
+					Env: []corev1.EnvVar{
+						{Name: "LANG", Value: "en_US.UTF-8"},
+						{Name: "TERM", Value: "xterm-256color"},
+					},
+				}
+				Expect(k8sClient.Update(ctx, &rolloutManager)).To(Succeed())
+				Eventually(func() []corev1.EnvVar {
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment)).To(Succeed())
+					return deployment.Spec.Template.Spec.Containers[0].Env
+				}, "10s", "1s").Should(ContainElements(
+					corev1.EnvVar{Name: "LANG", Value: "en_US.UTF-8"},
+					corev1.EnvVar{Name: "TERM", Value: "xterm-256color"},
+				))
+			})
+		})
+
+		When("A RolloutManager specifies an image", func() {
+			It("should reflect that image in the deployment", func() {
+				By("creating the deployment with the image specified in the RolloutManager")
+				rolloutManager.Spec = rolloutsmanagerv1alpha1.RolloutManagerSpec{
+					Image:   "quay.io/prometheus/busybox",
+					Version: "latest",
+				}
+				Expect(k8sClient.Create(ctx, &rolloutManager)).To(Succeed())
+
+				deployment := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+				}
+				Eventually(&deployment, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+				expectedVersion := rolloutManager.Spec.Image + ":" + rolloutManager.Spec.Version
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment)).To(Succeed())
+				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(expectedVersion))
+
+				By("updating the deployment when the image in the RolloutManager is updated")
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&rolloutManager), &rolloutManager)).To(Succeed())
+				rolloutManager.Spec = rolloutsmanagerv1alpha1.RolloutManagerSpec{
+					Image:   controllers.DefaultArgoRolloutsImage,
+					Version: controllers.DefaultArgoRolloutsVersion,
+				}
+				Expect(k8sClient.Update(ctx, &rolloutManager)).To(Succeed())
+				expectedVersion = controllers.DefaultArgoRolloutsImage + ":" + controllers.DefaultArgoRolloutsVersion
+				Eventually(func() string {
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment)).To(Succeed())
+					return deployment.Spec.Template.Spec.Containers[0].Image
+				}, "10s", "1s").Should(Equal(expectedVersion))
 			})
 		})
 	})
 })
+
+func ensureLabels(object *metav1.ObjectMeta) {
+	GinkgoHelper()
+	Expect(len(object.Labels)).To(Equal(3))
+	Expect(object.Labels["app.kubernetes.io/name"]).To(Equal(controllers.DefaultArgoRolloutsResourceName))
+	Expect(object.Labels["app.kubernetes.io/part-of"]).To(Equal(controllers.DefaultArgoRolloutsResourceName))
+	Expect(object.Labels["app.kubernetes.io/component"]).To(Equal(controllers.DefaultArgoRolloutsResourceName))
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:

- Updates `EnsureCleanSlate` to delete the Rollouts cluster roles
- Update the existing e2e tests
- Adds new e2e tests
- Fixes a bug in the operator where the wrong label was set on two of the three aggregated cluster roles

Fixes issue #26
