### PR TITLE
Upgrade to Argo Rollouts v1.6.6

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,9 +14,16 @@ jobs:
   lint_code:
     name: Run golangci-lint and gosec
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 'stable'
+
       - name: "run gosec"
         run: |
           cd $GITHUB_WORKSPACE

--- a/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-01-30T05:17:17Z"
+    createdAt: "2024-02-13T23:03:49Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: argo-rollouts-manager.v0.0.1

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -9,7 +9,7 @@ const (
 	// ArgoRolloutsDefaultImage is the default image for rollouts controller.
 	DefaultArgoRolloutsImage = "quay.io/argoproj/argo-rollouts"
 	// ArgoRolloutsDefaultVersion is the default version for the rollouts controller.
-	DefaultArgoRolloutsVersion = "v1.6.5" // v1.6.5
+	DefaultArgoRolloutsVersion = "v1.6.6" // v1.6.6
 	// DefaultArgoRolloutsResourceName is the default name for rollout controller resources such as
 	// deployment, service, role, rolebinding and serviceaccount.
 	DefaultArgoRolloutsResourceName = "argo-rollouts"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argo-rollouts-manager
 go 1.19
 
 require (
-	github.com/argoproj/argo-rollouts v1.6.5
+	github.com/argoproj/argo-rollouts v1.6.6
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj/argo-rollouts v1.6.5 h1:VDAp9PGboRbzd9tQJ/8IkaI+KrvWIRrpfSV5aeX0GUQ=
-github.com/argoproj/argo-rollouts v1.6.5/go.mod h1:X2kTiBaYCSounmw1kmONdIZTwJNzNQYC0SrXUgSw9UI=
+github.com/argoproj/argo-rollouts v1.6.6 h1:JCJ0cGAwWkh2xCAHZ1OQmrobysRjCatmG9IZaLJpS1g=
+github.com/argoproj/argo-rollouts v1.6.6/go.mod h1:X2kTiBaYCSounmw1kmONdIZTwJNzNQYC0SrXUgSw9UI=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CURRENT_ROLLOUTS_VERSION=v1.6.5
+CURRENT_ROLLOUTS_VERSION=v1.6.6
 
 function cleanup {
   echo "* Cleaning up"
@@ -148,4 +148,5 @@ if [ -n "$UNEXPECTED_FAILURES" ]; then
 else
   echo "* SUCCESS: No unexpected errors occurred."
 fi
+
 


### PR DESCRIPTION
Update to latest release of Argo Rollouts: https://github.com/argoproj/argo-rollouts/releases/tag/v1.6.6
Before merging this PR, ensure you check the Argo Rollouts change logs and release notes: 
- ensure there are no changes to the Argo Rollouts install YAML that we need to respond to with changes in the operator
- ensure there are no backwards incompatible API/behaviour changes in the change logs