### PR TITLE
Improve logic used to detect changes in Deployment resource

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -48,4 +48,5 @@ jobs:
           make start-e2e &
       - name: Run tests
         run: |
+          set -o pipefail
           make test-e2e 2>&1 | tee /tmp/e2e-test.log

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -45,10 +45,7 @@ jobs:
           go mod download
       - name: Run the operator locally
         run: |
-          set -o pipefail
-          make install generate fmt vet
-          go run ./main.go 2>&1 | tee /tmp/e2e-operator-run.log &
+          make start-e2e &
       - name: Run tests
         run: |
-          set -o pipefail
           make test-e2e 2>&1 | tee /tmp/e2e-test.log

--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,14 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -coverprofile cover.out `go list ./... | grep -v 'tests/e2e'`
 	
 
+.PHONY: start-e2e
+start-e2e: ## Start the operator, to run the e2e tests
+	hack/start-rollouts-manager-for-e2e-tests.sh
+
+
 .PHONY: test-e2e
 test-e2e: ## Run operator e2e tests
-	go test -v -p=1 -timeout=10m -race -count=1 -coverprofile=coverage.out ./tests/e2e
+	hack/run-rollouts-manager-e2e-tests.sh
 
 ##@ Build
 

--- a/controllers/argorollouts_controller.go
+++ b/controllers/argorollouts_controller.go
@@ -79,7 +79,7 @@ var log = logr.Log.WithName("rollouts-controller")
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *RolloutManagerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := logr.FromContext(ctx, "Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.Info("Reconciling Rollout Managers")
+	reqLogger.Info("Reconciling RolloutManager")
 
 	// Fetch the RolloutManager instance
 	rollouts := &rolloutsmanagerv1alpha1.RolloutManager{}

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -326,6 +326,10 @@ func normalizeDeployment(inputParam appsv1.Deployment) (appsv1.Deployment, error
 		return appsv1.Deployment{}, fmt.Errorf("incorrect liveness probe")
 	}
 
+	if inputLivenessProbe.ProbeHandler.HTTPGet == nil {
+		return appsv1.Deployment{}, fmt.Errorf("incorrect http get in liveness probe")
+	}
+
 	if inputReadinessProbe == nil {
 		return appsv1.Deployment{}, fmt.Errorf("incorrect readiness probe")
 	}

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -350,7 +350,7 @@ func normalizeDeployment(inputParam appsv1.Deployment) (appsv1.Deployment, error
 		return appsv1.Deployment{}, fmt.Errorf("incorrect volume mounts")
 	}
 
-	// String slices need to be converted to nil, because reflect.DeepEqual(nil, []string{}) is false, despite being functionally the same, here.
+	// Nil string slices need to be converted to empty string slices, because  reflect.DeepEqual(nil, []string{}) is false, despite being functionally the same, here.
 	if len(inputContainer.Args) == 0 {
 		inputContainer.Args = make([]string, 0)
 	}

--- a/controllers/deployment_test.go
+++ b/controllers/deployment_test.go
@@ -2,6 +2,8 @@ package rollouts
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	"github.com/argoproj-labs/argo-rollouts-manager/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -9,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Deployment Test", func() {
@@ -36,7 +39,7 @@ var _ = Describe("Deployment Test", func() {
 	It("should create a new deployment if it does not exist", func() {
 
 		By("calling reconcileRolloutsDeployment")
-		Expect(r.reconcileRolloutsDeployment(ctx, a, sa)).To(Succeed())
+		Expect(r.reconcileRolloutsDeployment(ctx, a, *sa)).To(Succeed())
 
 		By("fetch the Deployment")
 		fetchedDeployment := &appsv1.Deployment{}
@@ -64,7 +67,7 @@ var _ = Describe("Deployment Test", func() {
 		Expect(r.Client.Create(ctx, existingDeployment)).To(Succeed())
 
 		By("calling reconcileRolloutsDeployment")
-		Expect(r.reconcileRolloutsDeployment(ctx, a, sa)).To(Succeed())
+		Expect(r.reconcileRolloutsDeployment(ctx, a, *sa)).To(Succeed())
 
 		By("fetch the Deployment")
 		fetchedDeployment := &appsv1.Deployment{}
@@ -82,6 +85,131 @@ var _ = Describe("Deployment Test", func() {
 		Expect(fetchedDeployment.Spec.Template.Spec.Tolerations).To(Equal(expectedDeployment.Spec.Template.Spec.Tolerations))
 		Expect(fetchedDeployment.Spec.Template.Spec.SecurityContext).To(Equal(expectedDeployment.Spec.Template.Spec.SecurityContext))
 		Expect(fetchedDeployment.Spec.Template.Spec.Volumes).To(Equal(expectedDeployment.Spec.Template.Spec.Volumes))
+
+	})
+
+	When("the deployment has not changed", func() {
+		It("should not report any difference, both before and after normalization", func() {
+
+			expectedDeployment := deploymentCR(DefaultArgoRolloutsResourceName, a.Namespace, DefaultArgoRolloutsResourceName, "tmp", "linux", DefaultArgoRolloutsResourceName, a)
+			Expect(identifyDeploymentDifference(*expectedDeployment, *expectedDeployment)).To(Equal(""))
+
+			expectedDeployment = deploymentCR(DefaultArgoRolloutsResourceName, a.Namespace, DefaultArgoRolloutsResourceName, "tmp", "linux", DefaultArgoRolloutsResourceName, a)
+			expectedDeploymentNormalized, err := normalizeDeployment(*expectedDeployment)
+			Expect(err).To(Succeed())
+
+			Expect(identifyDeploymentDifference(expectedDeploymentNormalized, *expectedDeployment)).To(Equal(""))
+			Expect(identifyDeploymentDifference(*expectedDeployment, expectedDeploymentNormalized)).To(Equal(""))
+			Expect(identifyDeploymentDifference(*expectedDeployment, *expectedDeployment)).To(Equal(""))
+
+		})
+	})
+
+	When("the Rollouts Deployment resource is changed by the user, outside of the operator", func() {
+
+		areEqual := func(x appsv1.Deployment, y appsv1.Deployment) bool {
+			xRes, xErr := normalizeDeployment(x)
+			yRes, yErr := normalizeDeployment(y)
+
+			if fmt.Sprintf("%v", xErr) != fmt.Sprintf("%v", yErr) {
+				return false
+			}
+
+			res := reflect.DeepEqual(xRes, yRes)
+
+			// Sanity test that identifyDeploymentDifference gives the same result as reflect.DeepEqual
+			deploymentDiff := identifyDeploymentDifference(x, y)
+			Expect(res == (deploymentDiff == "")).To(BeTrue())
+
+			return res
+		}
+
+		DescribeTable("controller should detect and revert the change", func(fxn func(deployment *appsv1.Deployment)) {
+
+			By("ensuring that deploymentCR properly detects the change")
+			defaultDeployment := deploymentCR(DefaultArgoRolloutsResourceName, a.Namespace, DefaultArgoRolloutsResourceName, "tmp", "linux", DefaultArgoRolloutsResourceName, a)
+
+			defaultDeploymentModified := deploymentCR(DefaultArgoRolloutsResourceName, a.Namespace, DefaultArgoRolloutsResourceName, "tmp", "linux", DefaultArgoRolloutsResourceName, a)
+
+			Expect(identifyDeploymentDifference(*defaultDeployment, *defaultDeploymentModified)).To(BeEmpty(), "they should be the same before one is modified")
+
+			fxn(defaultDeploymentModified)
+			Expect(identifyDeploymentDifference(*defaultDeployment, *defaultDeploymentModified)).ToNot(BeEmpty(), "after being modified, they should no longer be the same")
+
+			By("ensuring the reconcileRolloutsDeployment will detect and revert the change")
+			{
+				By("calling reconcileRolloutsDeployment to create a default Deployment")
+				reconciledDepl := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: DefaultArgoRolloutsResourceName, Namespace: a.Namespace},
+				}
+				Expect(r.reconcileRolloutsDeployment(context.Background(), a, *sa)).To(Succeed())
+				Expect(r.Client.Get(context.Background(), client.ObjectKeyFromObject(&reconciledDepl), &reconciledDepl)).To(Succeed())
+				updatedDepl := reconciledDepl.DeepCopy()
+				Expect(areEqual(*updatedDepl, reconciledDepl)).To(BeTrue(), "copy should be same as original")
+
+				By("updating the Deployment using the function, and then updating the cluster resource")
+				fxn(updatedDepl)
+				Expect(r.Client.Update(context.Background(), updatedDepl)).To(Succeed())
+
+				By("retrieving the cluster resource after the update, to ensure it is equal to the updated version")
+				updatedDeplFromClient := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: DefaultArgoRolloutsResourceName, Namespace: a.Namespace},
+				}
+				Expect(r.Client.Get(context.Background(), client.ObjectKeyFromObject(&updatedDeplFromClient), &updatedDeplFromClient)).To(Succeed())
+				Expect(areEqual(*updatedDepl, updatedDeplFromClient)).To(BeTrue(), "resource on cluster should match the resource we called Update with")
+
+				Expect(areEqual(updatedDeplFromClient, reconciledDepl)).ToNot(BeTrue(), "resource on cluster should NOT match the original Deployment that was created by the call to reconcileRolloutsDeployment")
+
+				By("calling reconcileRolloutsDeployment again, it should revert the change back to default")
+				Expect(r.reconcileRolloutsDeployment(context.Background(), a, *sa)).To(Succeed())
+
+				finalDeplFromClient := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: DefaultArgoRolloutsResourceName, Namespace: a.Namespace},
+				}
+
+				By("retrieving the Deployment version from the cluster")
+				Expect(r.Client.Get(context.Background(), client.ObjectKeyFromObject(&finalDeplFromClient), &finalDeplFromClient)).To(Succeed())
+				Expect(areEqual(finalDeplFromClient, reconciledDepl)).To(BeTrue(), "version from cluster should have been reconciled back to the default")
+
+			}
+
+		},
+			Entry("label", func(deployment *appsv1.Deployment) {
+				deployment.ObjectMeta.Labels = map[string]string{"my": "label"}
+			}),
+			Entry("spec.selector", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"my": "label"},
+				}
+			}),
+			Entry(".spec.template.spec.containers.args", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].Args = []string{"new", "args"}
+			}),
+			Entry(".spec.template.spec.containers.env", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "my-env", Value: "my-env-value"}}
+			}),
+			Entry(".spec.template.spec.serviceAccountName", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.ServiceAccountName = "different-service-account-name"
+			}),
+			Entry(".spec.template.labels", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Labels = map[string]string{"new": "label"}
+			}),
+			Entry(".spec.template.spec.nodeSelector", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.NodeSelector = map[string]string{"my": "node"}
+			}),
+			Entry(".spec.template.spec.tolerations", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{{Key: "value"}}
+			}),
+			Entry(".spec.template.spec.securityContext", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeLocalhost},
+				}
+			}),
+			Entry(".spec.template.spec.volumes", func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Volumes = []corev1.Volume{{Name: "my-volume"}}
+			}),
+		)
 
 	})
 
@@ -118,7 +246,7 @@ func deploymentCR(name string, namespace string, label string, volumeName string
 					"kubernetes.io/os": nodeSelector,
 				},
 				Containers: []corev1.Container{
-					rolloutsContainer(rolloutManager),
+					rolloutsContainer(*rolloutManager),
 				},
 				ServiceAccountName: serviceAccount,
 				SecurityContext: &corev1.PodSecurityContext{

--- a/controllers/deployment_test.go
+++ b/controllers/deployment_test.go
@@ -139,13 +139,13 @@ var _ = Describe("Deployment Test", func() {
 			By("ensuring the reconcileRolloutsDeployment will detect and revert the change")
 			{
 				By("calling reconcileRolloutsDeployment to create a default Deployment")
-				reconciledDepl := appsv1.Deployment{
+				expectedDepl := appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{Name: DefaultArgoRolloutsResourceName, Namespace: a.Namespace},
 				}
 				Expect(r.reconcileRolloutsDeployment(context.Background(), a, *sa)).To(Succeed())
-				Expect(r.Client.Get(context.Background(), client.ObjectKeyFromObject(&reconciledDepl), &reconciledDepl)).To(Succeed())
-				updatedDepl := reconciledDepl.DeepCopy()
-				Expect(areEqual(*updatedDepl, reconciledDepl)).To(BeTrue(), "copy should be same as original")
+				Expect(r.Client.Get(context.Background(), client.ObjectKeyFromObject(&expectedDepl), &expectedDepl)).To(Succeed())
+				updatedDepl := expectedDepl.DeepCopy()
+				Expect(areEqual(*updatedDepl, expectedDepl)).To(BeTrue(), "copy should be same as original")
 
 				By("updating the Deployment using the function, and then updating the cluster resource")
 				fxn(updatedDepl)
@@ -158,7 +158,7 @@ var _ = Describe("Deployment Test", func() {
 				Expect(r.Client.Get(context.Background(), client.ObjectKeyFromObject(&updatedDeplFromClient), &updatedDeplFromClient)).To(Succeed())
 				Expect(areEqual(*updatedDepl, updatedDeplFromClient)).To(BeTrue(), "resource on cluster should match the resource we called Update with")
 
-				Expect(areEqual(updatedDeplFromClient, reconciledDepl)).ToNot(BeTrue(), "resource on cluster should NOT match the original Deployment that was created by the call to reconcileRolloutsDeployment")
+				Expect(areEqual(updatedDeplFromClient, expectedDepl)).ToNot(BeTrue(), "resource on cluster should NOT match the original Deployment that was created by the call to reconcileRolloutsDeployment")
 
 				By("calling reconcileRolloutsDeployment again, it should revert the change back to default")
 				Expect(r.reconcileRolloutsDeployment(context.Background(), a, *sa)).To(Succeed())
@@ -169,7 +169,7 @@ var _ = Describe("Deployment Test", func() {
 
 				By("retrieving the Deployment version from the cluster")
 				Expect(r.Client.Get(context.Background(), client.ObjectKeyFromObject(&finalDeplFromClient), &finalDeplFromClient)).To(Succeed())
-				Expect(areEqual(finalDeplFromClient, reconciledDepl)).To(BeTrue(), "version from cluster should have been reconciled back to the default")
+				Expect(areEqual(finalDeplFromClient, expectedDepl)).To(BeTrue(), "version from cluster should have been reconciled back to the default")
 
 			}
 

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -52,7 +52,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsManager(ctx context.Context,
 	}
 
 	log.Info("reconciling rollouts deployment")
-	if err := r.reconcileRolloutsDeployment(ctx, cr, sa); err != nil {
+	if err := r.reconcileRolloutsDeployment(ctx, cr, *sa); err != nil {
 		return err
 	}
 

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+SCRIPTPATH="$(
+  cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit
+  pwd -P
+)"
+
+cd "$SCRIPTPATH/.."
+
+set -o pipefail
+set -ex
+
+go test -v -p=1 -timeout=10m -race -count=1 -coverprofile=coverage.out ./tests/e2e
+
+set +e
+
+# If the output from the E2E operator is available, then check it for errors
+if [ -f "/tmp/e2e-operator-run.log" ]; then
+
+    # Grep the log for unexpected errors
+    # - Ignore errors that are expected to occur
+
+    ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "unable to create new content in namespace argo-rollouts because it is being terminated"`
+
+    ERRORS_FOUND=`echo $ERRORS_FOUND_TEXT | grep "ERROR" | wc -l`
+
+    if [ "$ERRORS_FOUND" != "0" ]; then
+        echo "Unexpected errors found: $ERRORS_FOUND_TEXT"
+        exit 1
+    fi
+
+fi

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -20,7 +20,7 @@ if [ -f "/tmp/e2e-operator-run.log" ]; then
     # Grep the log for unexpected errors
     # - Ignore errors that are expected to occur
 
-    ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "unable to create new content in namespace argo-rollouts because it is being terminated"`
+    ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "unable to create new content in namespace argo-rollouts because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again"`
 
     ERRORS_FOUND=`echo $ERRORS_FOUND_TEXT | grep "ERROR" | wc -l`
 

--- a/hack/start-rollouts-manager-for-e2e-tests.sh
+++ b/hack/start-rollouts-manager-for-e2e-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SCRIPTPATH="$(
+  cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit
+  pwd -P
+)"
+
+cd "$SCRIPTPATH/.."
+
+rm -f /tmp/e2e-operator-run.log || true
+
+set -o pipefail
+set -ex
+
+make install generate fmt vet
+go run ./main.go 2>&1 | tee /tmp/e2e-operator-run.log

--- a/hack/verify-rollouts-e2e-tests/main.go
+++ b/hack/verify-rollouts-e2e-tests/main.go
@@ -210,11 +210,16 @@ func waitAndGetE2EFileContents(testsE2EResultsLogPath string) ([]string, error) 
 		}
 
 		for _, line := range fileLines[lineIndexStart:] {
-			// example: DONE 6 runs, 144 tests, 6 skipped, 47 failures in 2279.668s
-			if strings.HasPrefix(line, "DONE ") || time.Now().After(expireTime) {
+			// example line: DONE 6 runs, 144 tests, 6 skipped, 47 failures in 2279.668s
+			if strings.HasPrefix(line, "DONE ") {
 				fmt.Println("E2E tests file is complete:", line)
 				return fileLines, nil
 			}
+		}
+
+		if time.Now().After(expireTime) {
+			fmt.Println("E2E tests file timed out waiting. Previous X lines were:", fileLines[lineIndexStart:])
+			return fileLines, nil
 		}
 
 		// Otherwise, wait a second then check again.

--- a/hack/verify-rollouts-e2e-tests/main.go
+++ b/hack/verify-rollouts-e2e-tests/main.go
@@ -190,9 +190,12 @@ func parseTestResultsFromFile(fileContents []string, testsExpectedToFailList []s
 	return testResults, nil
 }
 
-// waitAndGetE2EFileContents waits for the last line of the file to start with 'DONE' before returning the contents
-// This allows us to avoid a race condition with tee where the file contents of the file may not have been fully flushed.
+// waitAndGetE2EFileContents waits for one of the last 50 lines of the file to start with 'DONE' before returning the contents.
+// This allows us to avoid a race condition with tee where the file contents of the file may not have been fully written.
 func waitAndGetE2EFileContents(testsE2EResultsLogPath string) ([]string, error) {
+
+	// Return whatever we have after 1 minute has elapsed
+	expireTime := time.Now().Add(1 * time.Minute)
 
 	for {
 
@@ -201,16 +204,21 @@ func waitAndGetE2EFileContents(testsE2EResultsLogPath string) ([]string, error) 
 			return []string{}, err
 		}
 
-		lastLine := fileLines[len(fileLines)-1]
+		lineIndexStart := len(fileLines) - 50
+		if lineIndexStart < 0 {
+			lineIndexStart = 0
+		}
 
-		// example: DONE 6 runs, 144 tests, 6 skipped, 47 failures in 2279.668s
-		if strings.HasPrefix(lastLine, "DONE ") {
-			fmt.Println("E2E tests file is complete:", lastLine)
-			return fileLines, nil
+		for _, line := range fileLines[lineIndexStart:] {
+			// example: DONE 6 runs, 144 tests, 6 skipped, 47 failures in 2279.668s
+			if strings.HasPrefix(line, "DONE ") || time.Now().After(expireTime) {
+				fmt.Println("E2E tests file is complete:", line)
+				return fileLines, nil
+			}
 		}
 
 		// Otherwise, wait a second then check again.
-		fmt.Println("* Waiting for E2E test file to be complete:", lastLine)
+		fmt.Println("* Waiting for E2E test file to be complete")
 		time.Sleep(time.Second)
 	}
 


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Deployment changes
    - Update the logic used to detect Deployment changes. See comment on 'normalizeDeployment' for details. TL;DR: to normalize a Deployment for comparison, we create a new Deployment struct, and copy in only the fields we care about (from the un-normalized Deployment).
    - Unit tests for these changes

- Related E2E test changes:
    - Move operator e2e test logic into shell script
    - Operator E2E tests should fail if the operator itself has unexpected ERROR log entries: added a check for this
    - Ability to set SKIP_RUN_STEP to skip starting operator in upstream rollouts test
    - Improve logic of 'waitAndGetE2EFileContents' to now check last 50 lines, rather than last 1 line 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
Fixes #47

<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
