### PR TITLE
Add route to ClusterRole/Role, update plugin name in ConfigMap

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -276,6 +276,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - split.smi-spec.io
   resources:
   - trafficsplits

--- a/controllers/argorollouts_controller.go
+++ b/controllers/argorollouts_controller.go
@@ -76,6 +76,7 @@ var log = logr.Log.WithName("rollouts-controller")
 //+kubebuilder:rbac:groups="traefik.containo.us",resources=traefikservices,verbs=watch;get;update
 //+kubebuilder:rbac:groups="x.getambassador.io",resources=ambassadormappings;mappings,verbs=create;watch;get;update;list;delete
 //+kubebuilder:rbac:groups="apisix.apache.org",resources=apisixroutes,verbs=watch;get;update
+//+kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=create;watch;get;update;patch;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -19,12 +19,12 @@ const (
 	DefaultRolloutsSelectorKey = "app.kubernetes.io/name"
 
 	// OpenShiftRolloutPluginName is the plugin name for Openshift Route Plugin
-	OpenShiftRolloutPluginName = "argoproj-labs/openshift-route-plugin"
+	OpenShiftRolloutPluginName = "argoproj-labs/openshift"
 
 	// DefaultRolloutsConfigMapName is the default name of the ConfigMap that contains the Rollouts controller configuration
 	DefaultRolloutsConfigMapName = "argo-rollouts-config"
 
-	DefaultOpenShiftRoutePluginURL = "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift/releases/download/commit-2749e0ac96ba00ce6f4af19dc6d5358048227d77/rollouts-plugin-trafficrouter-openshift-linux-amd64"
+	DefaultOpenShiftRoutePluginURL = "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift/releases/download/commit-8d0b3c6c5c18341f9f019cf1015b56b0d0c6085b/rollouts-plugin-trafficrouter-openshift-linux-amd64"
 
 	// NamespaceScopedArgoRolloutsController is an environment variable that can be used to configure scope of Argo Rollouts controller
 	// Set true to allow only namespace-scoped Argo Rollouts controller deployment and false for cluster-scoped

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -832,6 +832,22 @@ func GetPolicyRules() []rbacv1.PolicyRule {
 				"update",
 			},
 		},
+		{
+			APIGroups: []string{
+				"route.openshift.io",
+			},
+			Resources: []string{
+				"routes",
+			},
+			Verbs: []string{
+				"create",
+				"watch",
+				"get",
+				"update",
+				"patch",
+				"list",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Use `argoproj-labs/openshift` as the value we set in the Argo Rollouts ConfigMap, to enable OpenShift Route Traffic Management plugin 
- Update to latest commit of openshift route plugin
- Add OpenShift Route to kubebuilder tags, and to the Role/ClusterRole that will be generated for RolloutsManager install
- Regenerate config YAML

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
N/A

<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
