### PR TITLE
Refactor RolloutManager status update logic to eliminate/reduce failed status update errors

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -15,7 +15,7 @@ import (
 const TrafficRouterPluginConfigMapKey = "trafficRouterPlugins"
 
 // Reconcile the Rollouts Default Config Map.
-func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr *rolloutsmanagerv1alpha1.RolloutManager) error {
+func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager) error {
 
 	if r.OpenShiftRoutePluginLocation == "" { // sanity test the plugin value
 		return fmt.Errorf("OpenShift Route Plugin location is not set")

--- a/controllers/configmap_test.go
+++ b/controllers/configmap_test.go
@@ -13,14 +13,14 @@ import (
 
 var _ = Describe("ConfigMap Test", func() {
 	var ctx context.Context
-	var a *v1alpha1.RolloutManager
+	var a v1alpha1.RolloutManager
 	var r *RolloutManagerReconciler
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		a = makeTestRolloutManager()
+		a = *makeTestRolloutManager()
 
-		r = makeTestReconciler(a)
+		r = makeTestReconciler(&a)
 		Expect(createNamespace(r, a.Namespace)).To(Succeed())
 	})
 

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -78,9 +78,9 @@ func generateDesiredRolloutsDeployment(cr rolloutsmanagerv1alpha1.RolloutManager
 }
 
 // Reconcile the Rollouts controller deployment.
-func (r *RolloutManagerReconciler) reconcileRolloutsDeployment(ctx context.Context, cr *rolloutsmanagerv1alpha1.RolloutManager, sa corev1.ServiceAccount) error {
+func (r *RolloutManagerReconciler) reconcileRolloutsDeployment(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager, sa corev1.ServiceAccount) error {
 
-	desiredDeployment := generateDesiredRolloutsDeployment(*cr, sa)
+	desiredDeployment := generateDesiredRolloutsDeployment(cr, sa)
 
 	normalizedDesiredDeployment, err := normalizeDeployment(desiredDeployment)
 	if err != nil {
@@ -104,7 +104,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsDeployment(ctx context.Conte
 			return fmt.Errorf("failed to get the Deployment %s: %w", DefaultArgoRolloutsResourceName, err)
 		}
 
-		if err := controllerutil.SetControllerReference(cr, &desiredDeployment, r.Scheme); err != nil {
+		if err := controllerutil.SetControllerReference(&cr, &desiredDeployment, r.Scheme); err != nil {
 			return err
 		}
 		log.Info(fmt.Sprintf("Creating Deployment %s", DefaultArgoRolloutsResourceName))

--- a/controllers/deployment_test.go
+++ b/controllers/deployment_test.go
@@ -16,15 +16,15 @@ import (
 
 var _ = Describe("Deployment Test", func() {
 	var ctx context.Context
-	var a *v1alpha1.RolloutManager
+	var a v1alpha1.RolloutManager
 	var r *RolloutManagerReconciler
 	var sa *corev1.ServiceAccount
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		a = makeTestRolloutManager()
+		a = *makeTestRolloutManager()
 
-		r = makeTestReconciler(a)
+		r = makeTestReconciler(&a)
 		Expect(createNamespace(r, a.Namespace)).To(Succeed())
 
 		sa = &corev1.ServiceAccount{
@@ -215,7 +215,7 @@ var _ = Describe("Deployment Test", func() {
 
 })
 
-func deploymentCR(name string, namespace string, label string, volumeName string, nodeSelector string, serviceAccount string, rolloutManager *v1alpha1.RolloutManager) *appsv1.Deployment {
+func deploymentCR(name string, namespace string, label string, volumeName string, nodeSelector string, serviceAccount string, rolloutManager v1alpha1.RolloutManager) *appsv1.Deployment {
 	runAsNonRoot := true
 	deploymentCR := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -246,7 +246,7 @@ func deploymentCR(name string, namespace string, label string, volumeName string
 					"kubernetes.io/os": nodeSelector,
 				},
 				Containers: []corev1.Container{
-					rolloutsContainer(*rolloutManager),
+					rolloutsContainer(rolloutManager),
 				},
 				ServiceAccountName: serviceAccount,
 				SecurityContext: &corev1.PodSecurityContext{

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -8,31 +8,48 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (r *RolloutManagerReconciler) reconcileRolloutsManager(ctx context.Context, cr *rolloutsmanagerv1alpha1.RolloutManager) (metav1.Condition, error) {
+// reconcileStatusResult is returned by 'reconcileRolloutsManager', and related functions, to control what values to set on the .status field of RolloutManager, after reconciliation. Values set in reconcileStatusResult will be set on RolloutManager's .status field.
+type reconcileStatusResult struct {
+
+	// condition to be set on RolloutManager's .status.condition
+	condition metav1.Condition
+
+	// rolloutController: if non-nil, .status.rolloutController will be set to this value, after call to reconcileRolloutsManager
+	rolloutController *rolloutsmanagerv1alpha1.RolloutControllerPhase
+
+	// phase: if non-nil, .status.phase will be set to this value, after call to reconcileRolloutsManager
+	phase *rolloutsmanagerv1alpha1.RolloutControllerPhase
+}
+
+func (r *RolloutManagerReconciler) reconcileRolloutsManager(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager) (reconcileStatusResult, error) {
 
 	log.Info("validating RolloutManager's scope")
-	if err := validateRolloutsScope(ctx, r.Client, cr, r.NamespaceScopedArgoRolloutsController); err != nil {
+	if rr, err := validateRolloutsScope(cr, r.NamespaceScopedArgoRolloutsController); err != nil {
 		if invalidRolloutScope(err) {
-			return createCondition(err.Error(), rolloutsmanagerv1alpha1.RolloutManagerReasonInvalidScoped), nil
+			rr.condition = createCondition(err.Error(), rolloutsmanagerv1alpha1.RolloutManagerReasonInvalidScoped)
+			return *rr, nil
 		}
 		log.Error(err, "failed to validate RolloutManager's scope.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	log.Info("searching for existing RolloutManagers")
-	if err := checkForExistingRolloutManager(ctx, r.Client, cr); err != nil {
+	if res, err := checkForExistingRolloutManager(ctx, r.Client, cr); err != nil {
 		if multipleRolloutManagersExist(err) {
-			return createCondition(err.Error(), rolloutsmanagerv1alpha1.RolloutManagerReasonMultipleClusterScopedRolloutManager), nil
+
+			res.condition = createCondition(err.Error(), rolloutsmanagerv1alpha1.RolloutManagerReasonMultipleClusterScopedRolloutManager)
+
+			return *res, nil
 		}
 		log.Error(err, "failed to validate multiple RolloutManagers.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	log.Info("reconciling Rollouts ServiceAccount")
 	sa, err := r.reconcileRolloutsServiceAccount(ctx, cr)
 	if err != nil {
 		log.Error(err, "failed to reconcile Rollout's ServiceAccount.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	var role *rbacv1.Role
@@ -43,78 +60,81 @@ func (r *RolloutManagerReconciler) reconcileRolloutsManager(ctx context.Context,
 		role, err = r.reconcileRolloutsRole(ctx, cr)
 		if err != nil {
 			log.Error(err, "failed to reconcile Rollout's Role.")
-			return createCondition(err.Error()), err
+			return wrapCondition(createCondition(err.Error())), err
 		}
 	} else {
 		log.Info("reconciling Rollouts ClusterRoles")
 		clusterRole, err = r.reconcileRolloutsClusterRole(ctx)
 		if err != nil {
 			log.Error(err, "failed to reconcile Rollout's ClusterRoles.")
-			return createCondition(err.Error()), err
+			return wrapCondition(createCondition(err.Error())), err
 		}
 	}
 
 	log.Info("reconciling aggregate-to-admin ClusterRole")
 	if err := r.reconcileRolloutsAggregateToAdminClusterRole(ctx); err != nil {
 		log.Error(err, "failed to reconcile Rollout's aggregate-to-admin ClusterRoles.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	log.Info("reconciling aggregate-to-edit ClusterRole")
 	if err := r.reconcileRolloutsAggregateToEditClusterRole(ctx); err != nil {
 		log.Error(err, "failed to reconcile Rollout's aggregate-to-edit ClusterRoles.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	log.Info("reconciling aggregate-to-view ClusterRole")
 	if err := r.reconcileRolloutsAggregateToViewClusterRole(ctx); err != nil {
 		log.Error(err, "failed to reconcile Rollout's aggregate-to-view ClusterRoles.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	if cr.Spec.NamespaceScoped {
 		log.Info("reconciling Rollouts RoleBindings")
 		if err := r.reconcileRolloutsRoleBinding(ctx, cr, role, sa); err != nil {
 			log.Error(err, "failed to reconcile Rollout's RoleBindings.")
-			return createCondition(err.Error()), err
+			return wrapCondition(createCondition(err.Error())), err
 		}
 	} else {
 		log.Info("reconciling Rollouts ClusterRoleBinding")
 		if err := r.reconcileRolloutsClusterRoleBinding(ctx, clusterRole, sa); err != nil {
 			log.Error(err, "failed to reconcile Rollout's ClusterRoleBinding.")
-			return createCondition(err.Error()), err
+			return wrapCondition(createCondition(err.Error())), err
 		}
 	}
 
 	log.Info("reconciling Rollouts Secret")
 	if err := r.reconcileRolloutsSecrets(ctx, cr); err != nil {
 		log.Error(err, "failed to reconcile Rollout's Secret.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	log.Info("reconciling ConfigMap for plugins")
 	if err := r.reconcileConfigMap(ctx, cr); err != nil {
 		log.Error(err, "failed to reconcile Rollout's ConfigMap.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	log.Info("reconciling Rollouts Deployment")
 	if err := r.reconcileRolloutsDeployment(ctx, cr, *sa); err != nil {
 		log.Error(err, "failed to reconcile Rollout's Deployment.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	log.Info("reconciling Rollouts Metrics Service")
 	if err := r.reconcileRolloutsMetricsService(ctx, cr); err != nil {
 		log.Error(err, "failed to reconcile Rollout's Metrics Service.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
 	log.Info("reconciling status of workloads")
-	if err := r.reconcileStatus(ctx, cr); err != nil {
+	rr, err := r.determineStatusPhase(ctx, cr)
+	if err != nil {
 		log.Error(err, "failed to reconcile status of workloads.")
-		return createCondition(err.Error()), err
+		return wrapCondition(createCondition(err.Error())), err
 	}
 
-	return createCondition(""), nil
+	rr.condition = createCondition("") // success
+
+	return rr, nil
 }

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Reconciles Rollouts ServiceAccount.
-func (r *RolloutManagerReconciler) reconcileRolloutsServiceAccount(ctx context.Context, cr *rolloutsmanagerv1alpha1.RolloutManager) (*corev1.ServiceAccount, error) {
+func (r *RolloutManagerReconciler) reconcileRolloutsServiceAccount(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager) (*corev1.ServiceAccount, error) {
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -31,7 +31,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsServiceAccount(ctx context.C
 			return nil, fmt.Errorf("failed to get the ServiceAccount associated with %s: %w", sa.Name, err)
 		}
 
-		if err := controllerutil.SetControllerReference(cr, sa, r.Scheme); err != nil {
+		if err := controllerutil.SetControllerReference(&cr, sa, r.Scheme); err != nil {
 			return nil, err
 		}
 
@@ -46,7 +46,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsServiceAccount(ctx context.C
 }
 
 // Reconciles Rollouts Role.
-func (r *RolloutManagerReconciler) reconcileRolloutsRole(ctx context.Context, cr *rolloutsmanagerv1alpha1.RolloutManager) (*rbacv1.Role, error) {
+func (r *RolloutManagerReconciler) reconcileRolloutsRole(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager) (*rbacv1.Role, error) {
 
 	expectedPolicyRules := GetPolicyRules()
 
@@ -63,7 +63,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsRole(ctx context.Context, cr
 			return nil, fmt.Errorf("failed to reconcile the Role for the ServiceAccount associated with %s: %w", role.Name, err)
 		}
 
-		if err = controllerutil.SetControllerReference(cr, role, r.Scheme); err != nil {
+		if err = controllerutil.SetControllerReference(&cr, role, r.Scheme); err != nil {
 			return nil, err
 		}
 
@@ -115,7 +115,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsClusterRole(ctx context.Cont
 }
 
 // Reconcile Rollouts RoleBinding.
-func (r *RolloutManagerReconciler) reconcileRolloutsRoleBinding(ctx context.Context, cr *rolloutsmanagerv1alpha1.RolloutManager, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
+func (r *RolloutManagerReconciler) reconcileRolloutsRoleBinding(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
 
 	if role == nil {
 		return fmt.Errorf("received Role is nil while reconciling RoleBinding")
@@ -155,7 +155,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsRoleBinding(ctx context.Cont
 			return fmt.Errorf("failed to get the RoleBinding associated with %s: %w", expectedRoleBinding.Name, err)
 		}
 
-		if err := controllerutil.SetControllerReference(cr, expectedRoleBinding, r.Scheme); err != nil {
+		if err := controllerutil.SetControllerReference(&cr, expectedRoleBinding, r.Scheme); err != nil {
 			return err
 		}
 
@@ -337,7 +337,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToViewClusterRole(c
 }
 
 // Reconcile Rollouts Metrics Service.
-func (r *RolloutManagerReconciler) reconcileRolloutsMetricsService(ctx context.Context, cr *rolloutsmanagerv1alpha1.RolloutManager) error {
+func (r *RolloutManagerReconciler) reconcileRolloutsMetricsService(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager) error {
 
 	expectedSvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -371,7 +371,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsMetricsService(ctx context.C
 			return fmt.Errorf("failed to get the Service %s: %w", expectedSvc.Name, err)
 		}
 
-		if err := controllerutil.SetControllerReference(cr, expectedSvc, r.Scheme); err != nil {
+		if err := controllerutil.SetControllerReference(&cr, expectedSvc, r.Scheme); err != nil {
 			return err
 		}
 
@@ -389,7 +389,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsMetricsService(ctx context.C
 }
 
 // Reconciles Secrets for Rollouts controller
-func (r *RolloutManagerReconciler) reconcileRolloutsSecrets(ctx context.Context, cr *rolloutsmanagerv1alpha1.RolloutManager) error {
+func (r *RolloutManagerReconciler) reconcileRolloutsSecrets(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultRolloutsNotificationSecretName,
@@ -403,7 +403,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsSecrets(ctx context.Context,
 			return fmt.Errorf("failed to get the Secret %s: %w", secret.Name, err)
 		}
 
-		if err := controllerutil.SetControllerReference(cr, secret, r.Scheme); err != nil {
+		if err := controllerutil.SetControllerReference(&cr, secret, r.Scheme); err != nil {
 			return err
 		}
 

--- a/controllers/resources_test.go
+++ b/controllers/resources_test.go
@@ -20,14 +20,14 @@ var _ = Describe("Resource creation and cleanup tests", func() {
 	Context("Resource creation test", func() {
 		var (
 			ctx context.Context
-			a   *v1alpha1.RolloutManager
+			a   v1alpha1.RolloutManager
 			r   *RolloutManagerReconciler
 		)
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			a = makeTestRolloutManager()
-			r = makeTestReconciler(a)
+			a = *makeTestRolloutManager()
+			r = makeTestReconciler(&a)
 			err := createNamespace(r, a.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -45,7 +45,7 @@ var _ = Describe("updateStatusConditionOfRolloutManager tests", func() {
 	})
 
 	When("reconcileStatusResult has a non-nil phase", func() {
-		It("should set the phase on the on the RolloutManager status", func() {
+		It("should set the phase on the RolloutManager status", func() {
 
 			Expect(k8sClient.Create(ctx, &rolloutsManager)).To(Succeed())
 
@@ -63,7 +63,7 @@ var _ = Describe("updateStatusConditionOfRolloutManager tests", func() {
 	})
 
 	When("reconcileStatusResult has a non-nil rolloutController", func() {
-		It("should set the phase on the on the RolloutManager status", func() {
+		It("should set the phase on the RolloutManager status", func() {
 
 			Expect(k8sClient.Create(ctx, &rolloutsManager)).To(Succeed())
 

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -31,7 +31,7 @@ var _ = Describe("updateStatusConditionOfRolloutManager tests", func() {
 
 		ctx = context.Background()
 		log = logger.FromContext(ctx)
-		k8sClient = fake.NewClientBuilder().WithScheme(s).Build()
+		k8sClient = fake.NewClientBuilder().WithStatusSubresource(&rolloutsmanagerv1alpha1.RolloutManager{}).WithScheme(s).Build()
 
 		rolloutsManager = rolloutsmanagerv1alpha1.RolloutManager{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Ensures that we only ever update `.status` field of RolloutManager from a single location in the code
    - We do this by refactoring reconcile logic to return a 'reconcileStatusResult', which indicates what values to set on the status.
- This allows us to avoid these 'status  errors we were seeing when running E2E tests: `2024-04-10T05:51:36Z	ERROR	rollouts-controller	unable to update status of RolloutManager	{"error": "Operation cannot be fulfilled on rolloutmanagers.argoproj.io \"basic-rollouts-manager\": the object has been modified; please apply your changes to the latest version and try again"}`
- This PR also adds a quick Namespace-deletion test, to allow us to prevent modification to resources in a Namespace that is being deleted (which lets us avoid nasty error messages in our E2E tests related to deletion)
    - This allows us to avoid these errors: `unable to create new content in namespace argo-rollouts because it is being terminated`

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
Fixes #?

<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
