### PR TITLE
Run the E2E tests that work for both cluster-scoped and namespace-scope modes, on both

### DIFF
--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -21,7 +21,7 @@ set -ex
 
 if [ "$NAMESPACE_SCOPED_ARGO_ROLLOUTS" == "true" ]; then
 
-  go test -v -p=1 -timeout=30m -race -count=1 -coverprofile=coverage.out ./tests/e2e/.  ./tests/e2e/namespace-scoped
+  go test -v -p=1 -timeout=30m -race -count=1 -coverprofile=coverage.out ./tests/e2e/namespace-scoped
 
 else
 

--- a/tests/e2e/cluster-scoped/cluster_scoped_rollouts_test.go
+++ b/tests/e2e/cluster-scoped/cluster_scoped_rollouts_test.go
@@ -23,6 +23,9 @@ import (
 
 var _ = Describe("Cluster-scoped RolloutManager tests", func() {
 
+	// Add the tests which are designed to run in both cluster-scoped and namespace-scoped modes.
+	utils.RunRolloutsTests(false)
+
 	Context("Testing cluster-scoped RolloutManager behaviour", func() {
 
 		var (

--- a/tests/e2e/fixture/fixture.go
+++ b/tests/e2e/fixture/fixture.go
@@ -67,7 +67,7 @@ func EnsureCleanSlate() error {
 	}
 
 	// create default namespace used for Rollouts controller
-	err = cleaner.ensureRlloutNamespaceExists(TestE2ENamespace)
+	err = cleaner.ensureRolloutNamespaceExists(TestE2ENamespace)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func EnsureCleanSlate() error {
 	return nil
 }
 
-func (cleaner *Cleaner) ensureRlloutNamespaceExists(namespaceParam string) error {
+func (cleaner *Cleaner) ensureRolloutNamespaceExists(namespaceParam string) error {
 	if err := cleaner.deleteNamespace(namespaceParam); err != nil {
 		return fmt.Errorf("unable to delete namespace '%s': %w", namespaceParam, err)
 	}

--- a/tests/e2e/namespace-scoped/namespace_scoped_rollouts_test.go
+++ b/tests/e2e/namespace-scoped/namespace_scoped_rollouts_test.go
@@ -25,6 +25,9 @@ import (
 
 var _ = Describe("Namespace-scoped RolloutManager tests", func() {
 
+	// Add the tests which are designed to run in both cluster-scoped and namespace-scoped modes.
+	utils.RunRolloutsTests(true)
+
 	Context("Testing namespace-scoped RolloutManager behaviour", func() {
 
 		var (


### PR DESCRIPTION
**What does this PR do / why we need it**:
- At the moment, we have a generic set of E2E tests defined in the `tests/e2e` package, but by default we only run these during namespace-scoped tests
- However, we can easily extend these tests to work in the cluster-scoped case as well.
- Now the tests will run for both cases.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

