### PR TITLE
Switch to quay.io for E2E test image to avoid throttling

### DIFF
--- a/tests/e2e/fixture/rollouts/fixture.go
+++ b/tests/e2e/fixture/rollouts/fixture.go
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
         # based on docker.io/kostiscodefresh/gitops-canary-app:v1.0
-		# mirrored to jgwest-redhat
+        # mirrored to jgwest-redhat
       - image: quay.io/jgwest-redhat/gitops-canary-app@sha256:4fdd3483fa119b413aa9e3c4459bfa2be399c0741ab7565d2a716e362fc1aa41
         name: webserver-simple
         ports:

--- a/tests/e2e/fixture/rollouts/fixture.go
+++ b/tests/e2e/fixture/rollouts/fixture.go
@@ -42,7 +42,9 @@ spec:
         app: test-argo-app
     spec:
       containers:
-      - image: docker.io/kostiscodefresh/gitops-canary-app:v1.0
+        # based on docker.io/kostiscodefresh/gitops-canary-app:v1.0
+		# mirrored to jgwest-redhat
+      - image: quay.io/jgwest-redhat/gitops-canary-app@sha256:4fdd3483fa119b413aa9e3c4459bfa2be399c0741ab7565d2a716e362fc1aa41
         name: webserver-simple
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Some of our E2E tests use a docker.io-hosted image with a generic tag, which means we are subject to docker.io rate limiting (causing E2E tests to fail), and the contents of the image may change arbitrarily
- I've mirrored the image to quay.io to avoid rate limiting on image pulls, and hardcoded the SHA in the test to ensure the content doesn't change
- There's probably an even better place for it, or an alternative image, but for this PR the perfect is the enemy of the good
