### PR TITLE
ClusterRole/ClusterRoleBinding should be deleted when RolloutManager is deleted

### DIFF
--- a/controllers/argorollouts_controller.go
+++ b/controllers/argorollouts_controller.go
@@ -233,7 +233,7 @@ func (r *RolloutManagerReconciler) enqueueOtherRolloutManagersExceptObj(context 
 	// List all other RolloutMangers on the cluster
 	rmList := rolloutsmanagerv1alpha1.RolloutManagerList{}
 	if err := r.List(context, &rmList); err != nil {
-		log.Error(err, "Unable to list all RolloutManagers in queueOtherRolloutManagers")
+		log.Error(err, "Unable to list all RolloutManagers in enqueueOtherRolloutManagersExceptObj")
 		return []reconcile.Request{}
 	}
 

--- a/controllers/argorollouts_controller_test.go
+++ b/controllers/argorollouts_controller_test.go
@@ -486,7 +486,7 @@ var _ = Describe("RolloutManagerReconciler tests", func() {
 			nsName := "namespace"
 
 			if namespaceofRolloutManagerStillExists {
-				createNamespace(r, nsName)
+				Expect(createNamespace(r, nsName)).To(Succeed())
 			}
 
 			req := reconcile.Request{

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -84,15 +84,28 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
 				}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
 
-				By("deleting the role")
-				Eventually(&rbacv1.Role{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
-				}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+				if namespaceScopedParam {
+					By("deleting the role")
+					Eventually(&rbacv1.Role{
+						ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+					}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
 
-				By("deleting the role binding")
-				Eventually(&rbacv1.RoleBinding{
-					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
-				}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+					By("deleting the role binding")
+					Eventually(&rbacv1.RoleBinding{
+						ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName, Namespace: rolloutManager.Namespace},
+					}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+
+				} else {
+					By("deleting the cluster role")
+					Eventually(&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName},
+					}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+
+					By("deleting the cluster role binding")
+					Eventually(&rbacv1.ClusterRoleBinding{
+						ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultArgoRolloutsResourceName},
+					}, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+				}
 
 				By("deleting the deployment")
 				Eventually(&appsv1.Deployment{


### PR DESCRIPTION
**What does this PR do / why we need it**:
- See [parent issue for details](https://github.com/argoproj-labs/argo-rollouts-manager/issues/68)
- When we detect that a `RolloutManager` is deleted, or the namespace of a `RolloutManager` is deleted, then we delete the corresponding ClusterRole/ClusterRoleBindings
- Update the operator watch logic to ensure we detect when ClusterRole/ClusterRoleBinding are deleted.
- Unit/E2E test updates to ensure the issue is resolved

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
Fixes #68 
Fixes #24

<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
