### PR TITLE
Preserve label/annotations on updated Deployments

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -31,7 +31,7 @@ func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr ro
 		},
 	}
 
-	setRolloutsLabelsAndAnnotationsToObject(&desiredConfigMap.ObjectMeta, &cr)
+	setRolloutsLabelsAndAnnotationsToObject(&desiredConfigMap.ObjectMeta, cr)
 
 	trafficRouterPlugins := []pluginItem{
 		{

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -333,8 +333,8 @@ func normalizeDeployment(inputParam appsv1.Deployment, cr rolloutsmanagerv1alpha
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:      input.Spec.Template.Labels,
-				Annotations: input.Spec.Template.Annotations,
+				Labels:      normalizeMap(input.Spec.Template.Labels),
+				Annotations: normalizeMap(input.Spec.Template.Annotations),
 			},
 			Spec: corev1.PodSpec{
 				NodeSelector:       input.Spec.Template.Spec.NodeSelector,
@@ -457,6 +457,14 @@ func normalizeDeployment(inputParam appsv1.Deployment, cr rolloutsmanagerv1alpha
 
 	return res, nil
 
+}
+
+// Confirm nil maps to empty map, to allow them to be compared by reflect.DeepEqual()
+func normalizeMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return make(map[string]string, 0)
+	}
+	return in
 }
 
 // boolPtr returns a pointer to val

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -26,7 +26,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsServiceAccount(ctx context.C
 			Namespace: cr.Namespace,
 		},
 	}
-	setRolloutsLabelsAndAnnotationsToObject(&sa.ObjectMeta, &cr)
+	setRolloutsLabelsAndAnnotationsToObject(&sa.ObjectMeta, cr)
 
 	if err := fetchObject(ctx, r.Client, cr.Namespace, sa.Name, sa); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -58,7 +58,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsRole(ctx context.Context, cr
 			Namespace: cr.Namespace,
 		},
 	}
-	setRolloutsLabelsAndAnnotationsToObject(&role.ObjectMeta, &cr)
+	setRolloutsLabelsAndAnnotationsToObject(&role.ObjectMeta, cr)
 
 	if err := fetchObject(ctx, r.Client, cr.Namespace, role.Name, role); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -94,7 +94,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsClusterRole(ctx context.Cont
 			Name: DefaultArgoRolloutsResourceName,
 		},
 	}
-	setRolloutsLabelsAndAnnotationsToObject(&clusterRole.ObjectMeta, &cr)
+	setRolloutsLabelsAndAnnotationsToObject(&clusterRole.ObjectMeta, cr)
 
 	if err := fetchObject(ctx, r.Client, "", clusterRole.Name, clusterRole); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -133,7 +133,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsRoleBinding(ctx context.Cont
 			Namespace: cr.Namespace,
 		},
 	}
-	setRolloutsLabelsAndAnnotationsToObject(&expectedRoleBinding.ObjectMeta, &cr)
+	setRolloutsLabelsAndAnnotationsToObject(&expectedRoleBinding.ObjectMeta, cr)
 
 	expectedRoleBinding.RoleRef = rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
@@ -193,7 +193,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsClusterRoleBinding(ctx conte
 			Name: DefaultArgoRolloutsResourceName,
 		},
 	}
-	setRolloutsLabelsAndAnnotationsToObject(&expectedClusterRoleBinding.ObjectMeta, &cr)
+	setRolloutsLabelsAndAnnotationsToObject(&expectedClusterRoleBinding.ObjectMeta, cr)
 
 	expectedClusterRoleBinding.RoleRef = rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
@@ -247,7 +247,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToAdminClusterRole(
 		},
 	}
 	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name, aggregationType)
-	setAdditionalRolloutsLabelsAndAnnotationsToObject(&clusterRole.ObjectMeta, &cr)
+	setAdditionalRolloutsLabelsAndAnnotationsToObject(&clusterRole.ObjectMeta, cr)
 
 	if err := fetchObject(ctx, r.Client, "", clusterRole.Name, clusterRole); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -283,7 +283,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToEditClusterRole(c
 		},
 	}
 	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name, aggregationType)
-	setAdditionalRolloutsLabelsAndAnnotationsToObject(&clusterRole.ObjectMeta, &cr)
+	setAdditionalRolloutsLabelsAndAnnotationsToObject(&clusterRole.ObjectMeta, cr)
 
 	if err := fetchObject(ctx, r.Client, "", clusterRole.Name, clusterRole); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -319,7 +319,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToViewClusterRole(c
 		},
 	}
 	setRolloutsAggregatedClusterRoleLabels(&clusterRole.ObjectMeta, name, aggregationType)
-	setAdditionalRolloutsLabelsAndAnnotationsToObject(&clusterRole.ObjectMeta, &cr)
+	setAdditionalRolloutsLabelsAndAnnotationsToObject(&clusterRole.ObjectMeta, cr)
 
 	if err := fetchObject(ctx, r.Client, "", clusterRole.Name, clusterRole); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -350,7 +350,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsMetricsService(ctx context.C
 			Namespace: cr.Namespace,
 		},
 	}
-	setRolloutsLabelsAndAnnotationsToObject(&expectedSvc.ObjectMeta, &cr)
+	setRolloutsLabelsAndAnnotationsToObject(&expectedSvc.ObjectMeta, cr)
 	// overwrite the annotations for Rollouts Metrics Service
 	expectedSvc.ObjectMeta.Labels["app.kubernetes.io/name"] = DefaultArgoRolloutsMetricsServiceName
 	expectedSvc.ObjectMeta.Labels["app.kubernetes.io/component"] = "server"
@@ -464,7 +464,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsSecrets(ctx context.Context,
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	setRolloutsLabelsAndAnnotationsToObject(&secret.ObjectMeta, &cr)
+	setRolloutsLabelsAndAnnotationsToObject(&secret.ObjectMeta, cr)
 
 	if err := fetchObject(ctx, r.Client, cr.Namespace, secret.Name, secret); err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -30,14 +30,14 @@ type pluginItem struct {
 	Sha256   string `json:"sha256" yaml:"sha256"`
 }
 
-func setRolloutsLabelsAndAnnotationsToObject(obj *metav1.ObjectMeta, cr *rolloutsmanagerv1alpha1.RolloutManager) {
+func setRolloutsLabelsAndAnnotationsToObject(obj *metav1.ObjectMeta, cr rolloutsmanagerv1alpha1.RolloutManager) {
 
 	setRolloutsLabelsAndAnnotations(obj)
 
 	setAdditionalRolloutsLabelsAndAnnotationsToObject(obj, cr)
 }
 
-func setAdditionalRolloutsLabelsAndAnnotationsToObject(obj *metav1.ObjectMeta, cr *rolloutsmanagerv1alpha1.RolloutManager) {
+func setAdditionalRolloutsLabelsAndAnnotationsToObject(obj *metav1.ObjectMeta, cr rolloutsmanagerv1alpha1.RolloutManager) {
 
 	if cr.Spec.AdditionalMetadata != nil {
 		if obj.Labels == nil {
@@ -83,6 +83,28 @@ func appendStringMap(src map[string]string, add map[string]string) map[string]st
 		res[key] = val
 	}
 	return res
+}
+
+// combineStringMaps will combine multiple maps: maps defined earlier in the 'maps' slice may have their values overriden by maps defined later in the 'maps' slice.
+func combineStringMaps(maps ...map[string]string) map[string]string {
+
+	if maps == nil {
+		return nil
+	}
+
+	res := make(map[string]string, 0)
+	for idx := range maps {
+		currMap := maps[idx]
+		if currMap == nil {
+			continue
+		}
+		for k, v := range maps[idx] {
+			res[k] = v
+		}
+	}
+
+	return res
+
 }
 
 // Merges two slices of EnvVar entries into a single one. If existing

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -270,6 +270,28 @@ var _ = Describe("checkForExistingRolloutManager tests", func() {
 	})
 })
 
+var _ = Describe("combineStringMaps tests", func() {
+
+	DescribeTable("test combineStringMaps", func(maps []map[string]string, expectedResult map[string]string) {
+		res := combineStringMaps(maps...)
+		Expect(res).To(Equal(expectedResult))
+	},
+		Entry("single element", append([]map[string]string{},
+			map[string]string{"a": "b", "1": "2"}),
+			map[string]string{"a": "b", "1": "2"}),
+		Entry("multiple elements, no overlap", append([]map[string]string{},
+			map[string]string{"a": "b", "1": "2"}, map[string]string{"c": "d", "3": "4"}),
+			map[string]string{"a": "b", "1": "2", "c": "d", "3": "4"}),
+		Entry("multiple elements with overlap, final element should take precedence", append([]map[string]string{},
+			map[string]string{"a": "b", "1": "2", "overlap1": "Z"}, map[string]string{"c": "d", "3": "4", "overlap1": "X"}),
+			map[string]string{"a": "b", "1": "2", "c": "d", "3": "4", "overlap1": "X"}),
+		Entry("nil param", nil, nil),
+		Entry("nil one param", append([]map[string]string{},
+			map[string]string{"a": "b", "1": "2"}, nil),
+			map[string]string{"a": "b", "1": "2"}),
+	)
+})
+
 var _ = Describe("validateRolloutsScope tests", func() {
 
 	var (

--- a/tests/e2e/fixture/k8s/fixture.go
+++ b/tests/e2e/fixture/k8s/fixture.go
@@ -43,3 +43,39 @@ func UpdateWithoutConflict(ctx context.Context, obj client.Object, k8sClient cli
 
 	return err
 }
+
+func HaveLabel(keyParam, valueParam string, k8sClient client.Client) matcher.GomegaMatcher {
+
+	return WithTransform(func(k8sObject client.Object) bool {
+
+		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(k8sObject), k8sObject)
+		Expect(err).ToNot(HaveOccurred())
+
+		for key, value := range k8sObject.GetLabels() {
+			if key == keyParam && value == valueParam {
+				return true
+			}
+		}
+
+		return false
+
+	}, BeTrue())
+}
+
+func HaveAnnotation(keyParam, valueParam string, k8sClient client.Client) matcher.GomegaMatcher {
+
+	return WithTransform(func(k8sObject client.Object) bool {
+
+		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(k8sObject), k8sObject)
+		Expect(err).ToNot(HaveOccurred())
+
+		for key, value := range k8sObject.GetAnnotations() {
+			if key == keyParam && value == valueParam {
+				return true
+			}
+		}
+
+		return false
+
+	}, BeTrue())
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:
- At present, when we reconcile a Rollout on an existing Deployment, and that Deployment contains labels/annotations that were not originally present, we will update the Deployment to remove those labels.
- However, labels/annotations can be added by other external tools in Kubernetes, and we should preserve them.
- Likewise, we should not update a Deployment if no other fields changes besides the labels/annotations.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
Fixes #72 

<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
