### PR TITLE
Upgrade to Argo Rollouts v1.7.1

### DIFF
--- a/bundle/manifests/argoproj.io_analysisruns.yaml
+++ b/bundle/manifests/argoproj.io_analysisruns.yaml
@@ -179,7 +179,6 @@ spec:
                         datadog:
                           properties:
                             aggregator:
-                              default: last
                               enum:
                               - avg
                               - min

--- a/bundle/manifests/argoproj.io_analysistemplates.yaml
+++ b/bundle/manifests/argoproj.io_analysistemplates.yaml
@@ -175,7 +175,6 @@ spec:
                         datadog:
                           properties:
                             aggregator:
-                              default: last
                               enum:
                               - avg
                               - min

--- a/bundle/manifests/argoproj.io_clusteranalysistemplates.yaml
+++ b/bundle/manifests/argoproj.io_clusteranalysistemplates.yaml
@@ -175,7 +175,6 @@ spec:
                         datadog:
                           properties:
                             aggregator:
-                              default: last
                               enum:
                               - avg
                               - min

--- a/config/crd/bases/analysis-run-crd.yaml
+++ b/config/crd/bases/analysis-run-crd.yaml
@@ -179,7 +179,6 @@ spec:
                         datadog:
                           properties:
                             aggregator:
-                              default: last
                               enum:
                               - avg
                               - min

--- a/config/crd/bases/analysis-template-crd.yaml
+++ b/config/crd/bases/analysis-template-crd.yaml
@@ -175,7 +175,6 @@ spec:
                         datadog:
                           properties:
                             aggregator:
-                              default: last
                               enum:
                               - avg
                               - min

--- a/config/crd/bases/cluster-analysis-template-crd.yaml
+++ b/config/crd/bases/cluster-analysis-template-crd.yaml
@@ -175,7 +175,6 @@ spec:
                         datadog:
                           properties:
                             aggregator:
-                              default: last
                               enum:
                               - avg
                               - min

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -12,7 +12,7 @@ const (
 	DefaultArgoRolloutsImage = "quay.io/argoproj/argo-rollouts"
 
 	// ArgoRolloutsDefaultVersion is the default version for the Rollouts controller.
-	DefaultArgoRolloutsVersion = "v1.7.0" // v1.7.0
+	DefaultArgoRolloutsVersion = "v1.7.1" // v1.7.1
 
 	// DefaultArgoRolloutsResourceName is the default name for Rollouts controller resources such as
 	// deployment, service, role, rolebinding and serviceaccount.

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CURRENT_ROLLOUTS_VERSION=v1.7.0
+CURRENT_ROLLOUTS_VERSION=v1.7.1
 
 function cleanup {
   echo "* Cleaning up"
@@ -118,4 +118,5 @@ set -e
 "$SCRIPT_DIR/verify-rollouts-e2e-tests/verify-e2e-test-results.sh" /tmp/test-e2e.log
 
 echo "* SUCCESS: No unexpected errors occurred."
+
 


### PR DESCRIPTION
Update to latest release of Argo Rollouts: https://github.com/argoproj/argo-rollouts/releases/tag/v1.7.1

Before merging this PR, ensure you check the Argo Rollouts change logs and release notes: 
- ensure there are no changes to the Argo Rollouts install YAML that we need to respond to with changes in the operator
- ensure there are no backwards incompatible API/behaviour changes in the change logs

The major change in v1.7.1 was the fix  to use volumes/volumemounts in `manifests/base/argo-rollouts-deployment.yaml`:
- I previously fixed this as part of these changes for the v1.7.0 PR:
    - https://github.com/argoproj-labs/argo-rollouts-manager/blob/028ed4a4f7a08f7160d8480def29b6b75b2fbfcb/controllers/deployment.go#L312
    - https://github.com/argoproj-labs/argo-rollouts-manager/blob/028ed4a4f7a08f7160d8480def29b6b75b2fbfcb/controllers/deployment.go#L85
