### PR TITLE
Add/Improve unit tests for controllers/utils.go file

### DIFF
--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -623,12 +623,11 @@ var _ = Describe("setAdditionalRolloutsLabelsAndAnnotationsToObject tests", func
 		})
 
 		Context("and obj.Labels and obj.Annotations are already set", func() {
-			BeforeEach(func() {
-				obj.Labels = map[string]string{"existingKey": "existingValue"}
-				obj.Annotations = map[string]string{"existingAnnotation": "existingValue"}
-			})
 
 			It("should merge labels and annotations", func() {
+				obj.Labels = map[string]string{"existingKey": "existingValue"}
+				obj.Annotations = map[string]string{"existingAnnotation": "existingValue"}
+
 				setAdditionalRolloutsLabelsAndAnnotationsToObject(obj, cr)
 				Expect(obj.Labels).To(HaveKeyWithValue("existingKey", "existingValue"))
 				Expect(obj.Labels).To(HaveKeyWithValue("key1", "value1"))
@@ -638,7 +637,8 @@ var _ = Describe("setAdditionalRolloutsLabelsAndAnnotationsToObject tests", func
 		})
 
 		Context("and obj.Labels and obj.Annotations are are already set with different values", func() {
-			BeforeEach(func() {
+
+			It("should replace the existing values with the new values", func() {
 				obj.Labels = map[string]string{"key1": "oldValue"}
 				obj.Annotations = map[string]string{"annotation1": "oldValue"}
 
@@ -646,9 +646,7 @@ var _ = Describe("setAdditionalRolloutsLabelsAndAnnotationsToObject tests", func
 					Labels:      map[string]string{"key1": "newValue"},
 					Annotations: map[string]string{"annotation1": "newValue"},
 				}
-			})
 
-			It("should replace the existing values with the new values", func() {
 				setAdditionalRolloutsLabelsAndAnnotationsToObject(obj, cr)
 				Expect(obj.Labels).To(HaveKeyWithValue("key1", "newValue"))
 				Expect(obj.Annotations).To(HaveKeyWithValue("annotation1", "newValue"))

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -83,10 +83,10 @@ var _ = Describe("updateStatusConditionOfRolloutManager tests", func() {
 	})
 
 	When("reconcileStatusResult contains a new condition to set on RolloutManger Status", func() {
-		It("should set condition on status", func() {
+		DescribeTable("ensure that status conditions are set accordingly", func(reason ...string) {
 			Expect(k8sClient.Create(ctx, &rolloutsManager)).To(Succeed())
 
-			newCondition := createCondition("my condition")
+			newCondition := createCondition("my condition", reason...)
 
 			rsr := reconcileStatusResult{
 				condition: newCondition,
@@ -97,8 +97,10 @@ var _ = Describe("updateStatusConditionOfRolloutManager tests", func() {
 
 			Expect(rolloutsManager.Status.Conditions).To(HaveLen(1))
 			Expect(rolloutsManager.Status.Conditions[0].Message).To(Equal(newCondition.Message))
-
-		})
+			Expect(rolloutsManager.Status.Conditions[0].Reason).To(Equal(newCondition.Reason))
+		},
+			Entry("should set condition on status"),
+			Entry("should return error when len(reason) > 1", "my reason 1", "my reason 2"))
 	})
 
 })


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/GITOPS-4780

added unit tests for :
- insertOrUpdateConditionsInSlice
- isMergable
- combineImageTag
- setAdditionalRolloutsLabelsAndAnnotationsToObject
- envMerge
- createCondition: Ensure an error is returned when len(reason) > 1

The functions present in JIRA ticket is already having unit tests :
- [validateRolloutsScope](https://github.com/argoproj-labs/argo-rollouts-manager/blob/main/controllers/utils_test.go#L295) 
- [checkForExistingRolloutManager](https://github.com/argoproj-labs/argo-rollouts-manager/blob/main/controllers/utils_test.go#L106)
