### PR TITLE
Switch to reset from rebase in rollouts upgrade script

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -215,7 +215,7 @@ func validateRolloutsScope(cr rolloutsmanagerv1alpha1.RolloutManager, namespaceS
 			return &reconcileStatusResult{
 				rolloutController: &phaseFailure,
 				phase:             &phaseFailure,
-			}, fmt.Errorf(UnsupportedRolloutManagerClusterScoped)
+			}, errors.New(UnsupportedRolloutManagerClusterScoped)
 
 		}
 
@@ -232,7 +232,7 @@ func validateRolloutsScope(cr rolloutsmanagerv1alpha1.RolloutManager, namespaceS
 			return &reconcileStatusResult{
 				rolloutController: &phaseFailure,
 				phase:             &phaseFailure,
-			}, fmt.Errorf(UnsupportedRolloutManagerNamespaceScoped)
+			}, errors.New(UnsupportedRolloutManagerNamespaceScoped)
 		}
 
 		// allow only cluster-scoped RolloutManager
@@ -273,7 +273,7 @@ func checkForExistingRolloutManager(ctx context.Context, k8sClient client.Client
 			return &reconcileStatusResult{
 				rolloutController: &phaseFailure,
 				phase:             &phaseFailure,
-			}, fmt.Errorf(UnsupportedRolloutManagerConfiguration)
+			}, errors.New(UnsupportedRolloutManagerConfiguration)
 
 		}
 	}

--- a/hack/upgrade-rollouts-script/main.go
+++ b/hack/upgrade-rollouts-script/main.go
@@ -137,7 +137,7 @@ func createNewCommitAndBranch(latestReleaseVersionTag string, latestReleaseVersi
 		{"git", "stash"},
 		{"git", "fetch", "parent"},
 		{"git", "checkout", "main"},
-		{"git", "rebase", "parent/main"},
+		{"git", "reset", "--hard", "parent/main"},
 		{"git", "checkout", "-b", newBranchName},
 	}
 


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Switch to hard reset,  from rebase, in rollouts upgrade script
- This avoids errors related to any unrelated changes that happen to be in the `master` branch.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
N/A
