### PR TITLE
Add experimental reconcile/rest API metric sanity test to E2E Tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -12,6 +12,7 @@ jobs:
 
   test-e2e:
     name: Run end-to-end tests
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/rollouts_e2e_tests.yml
+++ b/.github/workflows/rollouts_e2e_tests.yml
@@ -13,6 +13,7 @@ jobs:
   test-e2e:
     name: Run end-to-end tests from upstream Argo Rollouts repo
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       matrix:
         k3s-version: [ v1.28.2 ]

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ start-e2e-namespace-scoped-bg: ## Start the operator, to run the e2e tests
 
 .PHONY: start-e2e-cluster-scoped-bg 
 start-e2e-cluster-scoped-bg: ## Start the operator, to run the e2e tests
-	RUN_IN_BACKGROUND=true hack/start-rollouts-manager-for-e2e-tests.sh
+	RUN_IN_BACKGROUND=true  NAMESPACE_SCOPED_ARGO_ROLLOUTS=false hack/start-rollouts-manager-for-e2e-tests.sh
 
 
 .PHONY: test-e2e-namespace-scoped
@@ -145,7 +145,7 @@ test-e2e-namespace-scoped: ## Run operator e2e tests
 
 .PHONY: test-e2e-cluster-scoped
 test-e2e-cluster-scoped: ## Run operator e2e tests
-	hack/run-rollouts-manager-e2e-tests.sh
+	NAMESPACE_SCOPED_ARGO_ROLLOUTS=false hack/run-rollouts-manager-e2e-tests.sh
 
 .PHONY: start-test-e2e-all
 start-test-e2e-all: start-e2e-namespace-scoped-bg test-e2e-namespace-scoped start-e2e-cluster-scoped-bg test-e2e-cluster-scoped

--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -146,12 +146,12 @@ func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr ro
 		actualConfigMap.Data[TrafficRouterPluginConfigMapKey] = string(desiredTrafficRouterPluginString)
 		actualConfigMap.Data[MetricPluginConfigMapKey] = string(desiredMetricPluginString)
 
+		log.Info("Updating Rollouts ConfigMap due to detected difference")
+
 		// Update the ConfigMap in the cluster
 		if err := r.Client.Update(ctx, actualConfigMap); err != nil {
 			return fmt.Errorf("failed to update ConfigMap: %v", err)
 		}
-		log.Info("ConfigMap updated successfully")
-
 		// Restarting rollouts pod only if configMap is updated
 		if err := r.restartRolloutsPod(ctx, cr.Namespace); err != nil {
 			return err
@@ -183,8 +183,8 @@ func (r *RolloutManagerReconciler) restartRolloutsPod(ctx context.Context, names
 
 	for i := range podList.Items {
 		pod := podList.Items[i]
-		log.Info("Deleting Rollouts Pod", "podName", pod.Name)
 		if pod.ObjectMeta.DeletionTimestamp == nil {
+			log.Info("Deleting Rollouts Pod", "podName", pod.Name)
 			if err := r.Client.Delete(ctx, &pod); err != nil {
 				if errors.IsNotFound(err) {
 					log.Info(fmt.Sprintf("Pod %s already deleted", pod.Name))

--- a/controllers/configmap_test.go
+++ b/controllers/configmap_test.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,7 +18,7 @@ var _ = Describe("ConfigMap Test", func() {
 	var a v1alpha1.RolloutManager
 	var r *RolloutManagerReconciler
 	var sa *corev1.ServiceAccount
-	var existingDeployment *v1.Deployment
+	var existingDeployment *appsv1.Deployment
 	const trafficrouterPluginLocation = "https://custom-traffic-plugin-location"
 	const metricPluginLocation = "https://custom-metric-plugin-location"
 

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -46,7 +46,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsServiceAccount(ctx context.C
 	normalizedLiveServiceAccount := liveServiceAccount.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveServiceAccount.ObjectMeta, cr)
 
-	if !reflect.DeepEqual(normalizedLiveServiceAccount.Labels, expectedServiceAccount.Labels) || !reflect.DeepEqual(normalizedLiveServiceAccount.Annotations, expectedServiceAccount.Annotations) {
+	if !areStringMapsEqual(normalizedLiveServiceAccount.Labels, expectedServiceAccount.Labels) || !areStringMapsEqual(normalizedLiveServiceAccount.Annotations, expectedServiceAccount.Annotations) {
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of ServiceAccount %s do not match the expected state, hence updating it", liveServiceAccount.Name))
 
@@ -111,7 +111,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsRole(ctx context.Context, cr
 
 	removeUserLabelsAndAnnotations(&normalizedLiveRole.ObjectMeta, cr)
 
-	if !reflect.DeepEqual(normalizedLiveRole.Labels, expectedRole.Labels) || !reflect.DeepEqual(normalizedLiveRole.Annotations, expectedRole.Annotations) {
+	if !areStringMapsEqual(normalizedLiveRole.Labels, expectedRole.Labels) || !areStringMapsEqual(normalizedLiveRole.Annotations, expectedRole.Annotations) {
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of Role %s do not match the expected state, hence updating it", liveRole.Name))
 
@@ -165,7 +165,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsClusterRole(ctx context.Cont
 	normalizedLiveClusterRole := liveClusterRole.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveClusterRole.ObjectMeta, cr)
 
-	if !reflect.DeepEqual(normalizedLiveClusterRole.Labels, expectedClusterRole.Labels) || !reflect.DeepEqual(normalizedLiveClusterRole.Annotations, expectedClusterRole.Annotations) {
+	if !areStringMapsEqual(normalizedLiveClusterRole.Labels, expectedClusterRole.Labels) || !areStringMapsEqual(normalizedLiveClusterRole.Annotations, expectedClusterRole.Annotations) {
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of Role %s do not match the expected state, hence updating it", liveClusterRole.Name))
 
@@ -248,7 +248,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsRoleBinding(ctx context.Cont
 
 	normalizedLiveRoleBinding := liveRoleBinding.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveRoleBinding.ObjectMeta, cr)
-	if !reflect.DeepEqual(normalizedLiveRoleBinding.Labels, expectedRoleBinding.Labels) || !reflect.DeepEqual(normalizedLiveRoleBinding.Annotations, expectedRoleBinding.Annotations) {
+	if !areStringMapsEqual(normalizedLiveRoleBinding.Labels, expectedRoleBinding.Labels) || !areStringMapsEqual(normalizedLiveRoleBinding.Annotations, expectedRoleBinding.Annotations) {
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of RoleBinding %s do not match the expected state, hence updating it", liveRoleBinding.Name))
 
@@ -327,7 +327,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsClusterRoleBinding(ctx conte
 
 	normalizedLiveClusterRoleBinding := liveClusterRoleBinding.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveClusterRoleBinding.ObjectMeta, cr)
-	if !reflect.DeepEqual(normalizedLiveClusterRoleBinding.Labels, expectedClusterRoleBinding.Labels) || !reflect.DeepEqual(normalizedLiveClusterRoleBinding.Annotations, expectedClusterRoleBinding.Annotations) {
+	if !areStringMapsEqual(normalizedLiveClusterRoleBinding.Labels, expectedClusterRoleBinding.Labels) || !areStringMapsEqual(normalizedLiveClusterRoleBinding.Annotations, expectedClusterRoleBinding.Annotations) {
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of ClusterRoleBinding %s do not match the expected state, hence updating it", liveClusterRoleBinding.Name))
 
@@ -460,7 +460,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToAdminClusterRole(
 
 	normalizedLiveClusterRole := liveClusterRole.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveClusterRole.ObjectMeta, cr)
-	if !reflect.DeepEqual(normalizedLiveClusterRole.Labels, expectedClusterRole.Labels) || !reflect.DeepEqual(normalizedLiveClusterRole.Annotations, expectedClusterRole.Annotations) {
+	if !areStringMapsEqual(normalizedLiveClusterRole.Labels, expectedClusterRole.Labels) || !areStringMapsEqual(normalizedLiveClusterRole.Annotations, expectedClusterRole.Annotations) {
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of aggregated ClusterRole %s do not match the expected state, hence updating it", liveClusterRole.Name))
 
@@ -512,7 +512,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToEditClusterRole(c
 
 	normalizedLiveClusterRole := liveClusterRole.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveClusterRole.ObjectMeta, cr)
-	if !reflect.DeepEqual(normalizedLiveClusterRole.Labels, expectedClusterRole.Labels) || !reflect.DeepEqual(normalizedLiveClusterRole.Annotations, expectedClusterRole.Annotations) {
+	if !areStringMapsEqual(normalizedLiveClusterRole.Labels, expectedClusterRole.Labels) || !areStringMapsEqual(normalizedLiveClusterRole.Annotations, expectedClusterRole.Annotations) {
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of aggregated ClusterRole %s do not match the expected state, hence updating it", liveClusterRole.Name))
 
@@ -564,7 +564,8 @@ func (r *RolloutManagerReconciler) reconcileRolloutsAggregateToViewClusterRole(c
 
 	normalizedLiveClusterRole := liveClusterRole.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveClusterRole.ObjectMeta, cr)
-	if !reflect.DeepEqual(normalizedLiveClusterRole.Labels, expectedClusterRole.Labels) || !reflect.DeepEqual(normalizedLiveClusterRole.Annotations, expectedClusterRole.Annotations) {
+	if !areStringMapsEqual(normalizedLiveClusterRole.Labels, expectedClusterRole.Labels) || !areStringMapsEqual(normalizedLiveClusterRole.Annotations, expectedClusterRole.Annotations) {
+
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of aggregated ClusterRole %s do not match the expected state, hence updating it", liveClusterRole.Name))
 
@@ -702,7 +703,8 @@ func (r *RolloutManagerReconciler) reconcileRolloutsMetricsService(ctx context.C
 
 	normalizedLiveService := liveService.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveService.ObjectMeta, cr)
-	if !reflect.DeepEqual(normalizedLiveService.Labels, expectedSvc.Labels) || !reflect.DeepEqual(normalizedLiveService.Annotations, expectedSvc.Annotations) {
+	if !areStringMapsEqual(normalizedLiveService.Labels, expectedSvc.Labels) || !areStringMapsEqual(normalizedLiveService.Annotations, expectedSvc.Annotations) {
+
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of metrics Service %s do not match the expected state, hence updating it", liveService.Name))
 
@@ -778,7 +780,7 @@ func (r *RolloutManagerReconciler) reconcileRolloutsSecrets(ctx context.Context,
 	normalizedLiveSecret := liveSecret.DeepCopy()
 	removeUserLabelsAndAnnotations(&normalizedLiveSecret.ObjectMeta, cr)
 
-	if !reflect.DeepEqual(normalizedLiveSecret.Labels, expectedSecret.Labels) || !reflect.DeepEqual(normalizedLiveSecret.Annotations, expectedSecret.Annotations) {
+	if !areStringMapsEqual(normalizedLiveSecret.Labels, expectedSecret.Labels) || !areStringMapsEqual(normalizedLiveSecret.Annotations, expectedSecret.Annotations) {
 		updateNeeded = true
 		log.Info(fmt.Sprintf("Labels/Annotations of Secret %s do not match the expected state, hence updating it", liveSecret.Name))
 

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -5,6 +5,62 @@ SCRIPTPATH="$(
   pwd -P
 )"
 
+# Treat undefined variables as errors
+set -u
+
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+
+
+extract_metrics_data() {
+  
+  # 1) Extract REST client get/put/post metrics
+  
+  # Example: the metrics from /metric endpoint look like this:
+  # rest_client_requests_total{code="200",host="api.pgqqd-novoo-oqu.pa43.p3.openshiftapps.com:443",method="GET"} 42
+  # rest_client_requests_total{code="200",host="api.pgqqd-novoo-oqu.pa43.p3.openshiftapps.com:443",method="PUT"} 88
+  # rest_client_requests_total{code="201",host="api.pgqqd-novoo-oqu.pa43.p3.openshiftapps.com:443",method="POST"} 110
+
+  curl http://localhost:8080/metrics -o "$TMP_DIR/rollouts-metric-endpoint-output.txt"
+  GET_REQUESTS=`cat "$TMP_DIR/rollouts-metric-endpoint-output.txt" | grep "rest_client_requests_total" | grep "GET" | rev | cut -d' ' -f1`
+  PUT_REQUESTS=`cat "$TMP_DIR/rollouts-metric-endpoint-output.txt" | grep "rest_client_requests_total" | grep "PUT" | rev | cut -d' ' -f1`
+  POST_REQUESTS=`cat "$TMP_DIR/rollouts-metric-endpoint-output.txt" | grep "rest_client_requests_total" | grep "POST" | rev | cut -d' ' -f1`
+
+
+  if [[ "$GET_REQUESTS" == "" ]]; then
+    GET_REQUESTS=0
+  fi
+  if [[ "$POST_REQUESTS" == "" ]]; then
+    POST_REQUESTS=0
+  fi
+  if [[ "$PUT_REQUESTS" == "" ]]; then
+    PUT_REQUESTS=0
+  fi
+
+
+  # 2) Extract the # of RolloutManager reconciles
+
+  # Example: the metrics from /metric endpoint look like this:
+  # controller_runtime_reconcile_total{controller="rolloutmanager",result="error"} 0
+  # controller_runtime_reconcile_total{controller="rolloutmanager",result="requeue"} 0
+  # controller_runtime_reconcile_total{controller="rolloutmanager",result="requeue_after"} 0
+  # controller_runtime_reconcile_total{controller="rolloutmanager",result="success"} 135
+  ERROR_RECONCILES=`cat "$TMP_DIR/rollouts-metric-endpoint-output.txt" | grep "controller_runtime_reconcile_total" | grep "error" | rev | cut -d' ' -f1`
+  SUCCESS_RECONCILES=`cat "$TMP_DIR/rollouts-metric-endpoint-output.txt" | grep "controller_runtime_reconcile_total" | grep "success" | rev | cut -d' ' -f1`
+
+  if [[ "$ERROR_RECONCILES" == "" ]]; then
+    ERROR_RECONCILES=0
+  fi
+
+  if [[ "$SUCCESS_RECONCILES" == "" ]]; then
+    SUCCESS_RECONCILES=0
+  fi
+
+}
+
+
+
+
+
 cd "$SCRIPTPATH/.."
 
 set -o pipefail
@@ -13,11 +69,23 @@ set -o pipefail
 kubectl get crd/servicemonitors.monitoring.coreos.com &> /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
-    # If the CRD is not found, apply the CRD YAML
-    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.52/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+  # If the CRD is not found, apply the CRD YAML
+  kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.52/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 fi
 
+
+# Before the test starts, extract initial metrics values
+extract_metrics_data
+
+INITIAL_GET_REQUESTS=$GET_REQUESTS
+INITIAL_PUT_REQUESTS=$PUT_REQUESTS
+INITIAL_POST_REQUESTS=$POST_REQUESTS
+INITIAL_ERROR_RECONCILES=$ERROR_RECONCILES
+INITIAL_SUCCESS_RECONCILES=$SUCCESS_RECONCILES
+
+
 set -ex
+
 
 if [ "$NAMESPACE_SCOPED_ARGO_ROLLOUTS" == "true" ]; then
 
@@ -28,7 +96,6 @@ else
   go test -v -p=1 -timeout=30m -race -count=1 -coverprofile=coverage.out ./tests/e2e/cluster-scoped
 
 fi
-
 
 set +e
 
@@ -51,3 +118,60 @@ if [ -f "/tmp/e2e-operator-run.log" ]; then
       exit 1
   fi
 fi
+
+
+extract_metrics_data
+
+set -x
+
+FINAL_GET_REQUESTS=$GET_REQUESTS
+FINAL_PUT_REQUESTS=$PUT_REQUESTS
+FINAL_POST_REQUESTS=$POST_REQUESTS
+FINAL_ERROR_RECONCILES=$ERROR_RECONCILES
+FINAL_SUCCESS_RECONCILES=$SUCCESS_RECONCILES
+
+DELTA_GET_REQUESTS=`expr $FINAL_GET_REQUESTS - $INITIAL_GET_REQUESTS`
+DELTA_PUT_REQUESTS=`expr $FINAL_PUT_REQUESTS - $INITIAL_PUT_REQUESTS`
+DELTA_POST_REQUESTS=`expr $FINAL_POST_REQUESTS - $INITIAL_POST_REQUESTS`
+
+DELTA_ERROR_RECONCILES=`expr $FINAL_ERROR_RECONCILES - $INITIAL_ERROR_RECONCILES`
+DELTA_SUCCESS_RECONCILES=`expr $FINAL_SUCCESS_RECONCILES - $INITIAL_SUCCESS_RECONCILES`
+
+
+if [[ "$DELTA_POST_REQUESTS" == "0" ]]; then
+  echo "Unexpected number of REST client post requests: should be at least 1"
+  exit 1
+fi 
+
+# Sanity test the behaviour of the operator during the tests
+
+# The # of PUT requests should be less than 40% of the # of POST requests
+# - If the number is higher, this implies we are updating the .status or .spec fields of resources more than is necessary.
+PUT_REQUEST_PERCENT=`expr "$DELTA_PUT_REQUESTS"00 / $DELTA_POST_REQUESTS`
+
+if [[ "`expr $PUT_REQUEST_PERCENT \> 40`" == "1" ]]; then
+
+  echo "Put request %$PUT_REQUEST_PERCENT was greater than the expected value"
+  exit 1
+
+fi
+
+if [[ "`expr $DELTA_ERROR_RECONCILES \> 20`" == "1" ]]; then
+
+  echo "Number of Reconcile calls that returned an error $DELTA_ERROR_RECONCILES was greater than the expected value"
+  exit 1
+
+fi
+
+if [[ "`expr $DELTA_SUCCESS_RECONCILES \> 200`" == "1" ]]; then
+
+  echo "Number of Reconcile calls that returned success $DELTA_SUCCESS_RECONCILES was greater than the expected value"
+  exit 1
+
+fi
+
+
+
+
+# The # of reconcile calls should be within an expected 
+# - This may need to be updated as we add new E2E tests.

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -157,7 +157,7 @@ sanity_test_metrics_data() {
 
   fi
 
-  if [[ "`expr $DELTA_SUCCESS_RECONCILES \> 250`" == "1" ]]; then
+  if [[ "`expr $DELTA_SUCCESS_RECONCILES \> 1200`" == "1" ]]; then
     # This value is arbitrary, and should be updated if at any point it becomes inaccurate (but first audit the test/code to make sure it is not an actual product/test issue, before increasing)
 
     echo "Number of Reconcile calls that returned success $DELTA_SUCCESS_RECONCILES was greater than the expected value"
@@ -181,11 +181,19 @@ if [ -f "/tmp/e2e-operator-run.log" ]; then
   # Grep the log for unexpected errors
   # - Ignore errors that are expected to occur
 
-  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError"` | grep -v "client rate limiter Wait returned an error: context canceled"
-  UNEXPECTED_ERRORS_COUNT=`echo $UNEXPECTED_ERRORS_FOUND_TEXT | grep "ERROR" | wc -l`
+  set +u # allow undefined vars
+
+  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled"`
+
+  if [ "$UNEXPECTED_ERRORS_FOUND_TEXT" != "" ]; then
   
-  if [ "$UNEXPECTED_ERRORS_COUNT" != "0" ]; then
-      echo "Unexpected errors found: $UNEXPECTED_ERRORS_FOUND_TEXT"
-      exit 1
+    UNEXPECTED_ERRORS_COUNT=`echo $UNEXPECTED_ERRORS_FOUND_TEXT | grep "ERROR" | wc -l`
+    
+    if [ "$UNEXPECTED_ERRORS_COUNT" != "0" ]; then
+        echo "Unexpected errors found: $UNEXPECTED_ERRORS_FOUND_TEXT"
+        exit 1
+    fi  
   fi
+
+
 fi

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -150,9 +150,9 @@ sanity_test_metrics_data() {
 
   fi
 
-  if [[ "`expr $DELTA_ERROR_RECONCILES \> 30`" == "1" ]]; then
+  if [[ "`expr $DELTA_ERROR_RECONCILES \> 60`" == "1" ]]; then
     # This value is arbitrary, and should be updated if at any point it becomes inaccurate (but first audit the test/code to make sure it is not an actual product/test issue, before increasing)
-    echo "Number of Reconcile calls that returned an error $DELTA_ERROR_RECONCILES was greater than the expected value"
+    echo "Number of Reconcile calls that returned an error '$DELTA_ERROR_RECONCILES' was greater than the expected value"
     exit 1
 
   fi
@@ -160,7 +160,7 @@ sanity_test_metrics_data() {
   if [[ "`expr $DELTA_SUCCESS_RECONCILES \> 1200`" == "1" ]]; then
     # This value is arbitrary, and should be updated if at any point it becomes inaccurate (but first audit the test/code to make sure it is not an actual product/test issue, before increasing)
 
-    echo "Number of Reconcile calls that returned success $DELTA_SUCCESS_RECONCILES was greater than the expected value"
+    echo "Number of Reconcile calls that returned success '$DELTA_SUCCESS_RECONCILES' was greater than the expected value"
     exit 1
 
   fi


### PR DESCRIPTION
**What does this PR do / why we need it**:
- This PR adds logic to sanity test the behaviour of the operator during the tests:
    - We check the (prometheus) metrics coming from the 'localhost:8080/metrics' endpoint of the operator.
    - For example, if the reported # of Reconcile calls was unusually high, this might mean that the operator was stuck in a Reconcile loop
    - Or, if the number of REST client POST requests (e.g. k8s objection creation) was equal to the number of PUT request (e.g. k8s object update), this may imply we are updating .status or .spec of an object too frequently.
- After this was enabled, I noticed we were reconciling too often, and I discovered that in many cases we were incorrectly detecting cases where nothing had changed, as something having changed. 
    - This was due to known issues with comparing maps using reflect.DeepEqual, so I switched over to use a substitute function for this case.
    - I also noticed we were stripping out rbac.authorization.k8s.io/* as a user-defined label, when it is in fact not user-defined, so added it to ignore list.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
N/A

