### PR TITLE
Add support for multi-arch images to E2E tests

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -215,7 +215,7 @@ func validateRolloutsScope(cr rolloutsmanagerv1alpha1.RolloutManager, namespaceS
 			return &reconcileStatusResult{
 				rolloutController: &phaseFailure,
 				phase:             &phaseFailure,
-			}, fmt.Errorf(UnsupportedRolloutManagerClusterScoped)
+			}, errors.New(UnsupportedRolloutManagerClusterScoped)
 
 		}
 
@@ -232,7 +232,7 @@ func validateRolloutsScope(cr rolloutsmanagerv1alpha1.RolloutManager, namespaceS
 			return &reconcileStatusResult{
 				rolloutController: &phaseFailure,
 				phase:             &phaseFailure,
-			}, fmt.Errorf(UnsupportedRolloutManagerNamespaceScoped)
+			}, errors.New(UnsupportedRolloutManagerNamespaceScoped)
 		}
 
 		// allow only cluster-scoped RolloutManager
@@ -273,7 +273,7 @@ func checkForExistingRolloutManager(ctx context.Context, k8sClient client.Client
 			return &reconcileStatusResult{
 				rolloutController: &phaseFailure,
 				phase:             &phaseFailure,
-			}, fmt.Errorf(UnsupportedRolloutManagerConfiguration)
+			}, errors.New(UnsupportedRolloutManagerConfiguration)
 
 		}
 	}

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -43,7 +43,7 @@ if [ -f "/tmp/e2e-operator-run.log" ]; then
   # Grep the log for unexpected errors
   # - Ignore errors that are expected to occur
 
-  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError"`
+  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError"` | grep -v "client rate limiter Wait returned an error: context canceled"
   UNEXPECTED_ERRORS_COUNT=`echo $UNEXPECTED_ERRORS_FOUND_TEXT | grep "ERROR" | wc -l`
   
   if [ "$UNEXPECTED_ERRORS_COUNT" != "0" ]; then

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -25,7 +25,12 @@ cd argo-rollouts
 git checkout $CURRENT_ROLLOUTS_VERSION
 go mod tidy
 
-# 2) Setup the Namespace
+# 2) Replace 'argoproj/rollouts-demo' image with 'quay.io/jgwest-redhat/rollouts-demo' in E2E tests
+# - The original 'argoproj/rollouts-demo' repository only has amd64 images, thus some of the E2E tests will not work on it.
+# - 'quay.io/jgwest-redhat/rollouts-demo' is based on the same code, but built for other archs
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/argoproj\/rollouts-demo/quay.io\/jgwest-redhat\/rollouts-demo/g'
+
+# 3) Setup the Namespace
 
 kubectl delete ns argo-rollouts || true
 
@@ -35,7 +40,7 @@ kubectl create ns argo-rollouts
 kubectl config set-context --current --namespace=argo-rollouts
 
 
-# 3) Build, install, and start the argo-rollouts-manager controller
+# 4) Build, install, and start the argo-rollouts-manager controller
 cd $SCRIPT_DIR/..
 
 
@@ -52,7 +57,7 @@ if [ -z "$SKIP_RUN_STEP" ]; then
   set -e
 fi
 
-# 4) Install Argo Rollouts into the Namespace via RolloutManager CR
+# 5) Install Argo Rollouts into the Namespace via RolloutManager CR
 
 cd $TMP_DIR/argo-rollouts
 
@@ -89,7 +94,7 @@ oc adm policy add-scc-to-user anyuid -z argo-rollouts -n argo-rollouts || true
 oc adm policy add-scc-to-user anyuid -z default -n argo-rollouts || true
 
 
-# 5) Run the E2E tests
+# 6) Run the E2E tests
 rm -f /tmp/test-e2e.log
 
 set +e
@@ -98,7 +103,7 @@ make test-e2e | tee /tmp/test-e2e.log
 
 set +x
 
-# 6) Check and report the results for unexpected failures
+# 7) Check and report the results for unexpected failures
 
 echo "-----------------------------------------------------------------"
 echo

--- a/tests/e2e/fixture/rollouts/fixture.go
+++ b/tests/e2e/fixture/rollouts/fixture.go
@@ -42,9 +42,8 @@ spec:
         app: test-argo-app
     spec:
       containers:
-        # based on docker.io/kostiscodefresh/gitops-canary-app:v1.0
-        # mirrored to jgwest-redhat
-      - image: quay.io/jgwest-redhat/gitops-canary-app@sha256:4fdd3483fa119b413aa9e3c4459bfa2be399c0741ab7565d2a716e362fc1aa41
+      - image: nginxinc/nginx-unprivileged@sha256:0569e319d06556564ad40882ed35231461d06bec788b5aec00b83b6e9f3ced1a
+        # nginx v1.27, from https://hub.docker.com/layers/nginxinc/nginx-unprivileged/1.27/images/sha256-37404ae33c744fe1c1e1f752225f986ff32c0327240ab6e960573c0f6cb577c3?context=explore
         name: webserver-simple
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Switch to nginx-unprivileged image, since it has an multi-arch image available, and runs in restricted Namespace
- Switch to multi-arch image for `rollouts-demo` image for upstream E2E tests (image is otherwise unmodified)
    - [Changes were made to rollouts-demo repo to add multi-arch support](https://github.com/argoproj/rollouts-demo/compare/master...jgwest:rollouts-demo:add-multi-image-builds?expand=1)
- Add an additional expected error to list.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
N/A

**How to test changes / Special notes to the reviewer**: N/A
