### PR TITLE
Upgrade to Argo Rollouts v1.7.2

### DIFF
--- a/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-07-29T13:09:50Z"
+    createdAt: "2024-09-27T12:15:43Z"
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: argo-rollouts-manager.v0.0.1

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -12,7 +12,7 @@ const (
 	DefaultArgoRolloutsImage = "quay.io/argoproj/argo-rollouts"
 
 	// ArgoRolloutsDefaultVersion is the default version for the Rollouts controller.
-	DefaultArgoRolloutsVersion = "v1.7.1" // v1.7.1
+	DefaultArgoRolloutsVersion = "v1.7.2" // v1.7.2
 
 	// DefaultArgoRolloutsResourceName is the default name for Rollouts controller resources such as
 	// deployment, service, role, rolebinding and serviceaccount.

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CURRENT_ROLLOUTS_VERSION=v1.7.1
+CURRENT_ROLLOUTS_VERSION=v1.7.2
 
 function cleanup {
   echo "* Cleaning up"
@@ -118,5 +118,6 @@ set -e
 "$SCRIPT_DIR/verify-rollouts-e2e-tests/verify-e2e-test-results.sh" /tmp/test-e2e.log
 
 echo "* SUCCESS: No unexpected errors occurred."
+
 
 

--- a/hack/upgrade-rollouts-script/main.go
+++ b/hack/upgrade-rollouts-script/main.go
@@ -115,8 +115,10 @@ func main() {
 
 		bodyText += `
 Before merging this PR, ensure you check the Argo Rollouts change logs and release notes: 
-- ensure there are no changes to the Argo Rollouts install YAML that we need to respond to with changes in the operator
-- ensure there are no backwards incompatible API/behaviour changes in the change logs`
+- Ensure there are no changes to the Argo Rollouts install YAML that we need to respond to with changes in the operator
+    - You can do this by downloading the 'install.yaml' from both the previous version (for example, v1.7.1) and new version (for example, v1.7.2), and then comparing them using a tool like [Meld](https://gitlab.gnome.org/GNOME/meld) or diff.
+	- If there are changes to resources like Deployments and Roles in the install.yaml between the two versions, this will likely require a corresponding code change within the operator. e.g. a new permission added to a Role would require a change to the Role creation code in the operator.
+- Ensure there are no backwards incompatible API/behaviour changes in the change logs`
 
 		// 4) Create PR if it doesn't exist
 		if stdout, stderr, err := runCommandWithWorkDir(pathToGitHubRepo, "gh", "pr", "create",


### PR DESCRIPTION
Update to latest release of Argo Rollouts: https://github.com/argoproj/argo-rollouts/releases/tag/v1.7.2
Before merging this PR, ensure you check the Argo Rollouts change logs and release notes: 
- ensure there are no changes to the Argo Rollouts install YAML that we need to respond to with changes in the operator
- ensure there are no backwards incompatible API/behaviour changes in the change logs