### PR TITLE
fix: delete existing  RBAC resources while switching scope of Rollouts

### DIFF
--- a/controllers/resources_test.go
+++ b/controllers/resources_test.go
@@ -1139,6 +1139,112 @@ var _ = Describe("Resource creation and cleanup tests", func() {
 		})
 	})
 
+	Context("Verify correct RBAC permissions are assigned while switching between namespace and cluster scoped Rollouts", func() {
+		var (
+			ctx context.Context
+			a   v1alpha1.RolloutManager
+			r   *RolloutManagerReconciler
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			a = *makeTestRolloutManager()
+			r = makeTestReconciler(&a)
+			err := createNamespace(r, a.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should delete existing Role when ClusterRole is reconciled", func() {
+			By("Reconcile Role.")
+			role, err := r.reconcileRolloutsRole(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify Role is created")
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(role), role)).To(Succeed())
+
+			By("Reconcile ClusterRole")
+			clusterRole, err := r.reconcileRolloutsClusterRole(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify ClusterRole is created")
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).To(Succeed())
+
+			By("Verify existing Role is deleted")
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(role), role)).To(HaveOccurred())
+		})
+
+		It("Should delete existing ClusterRole when Role is reconciled", func() {
+
+			By("Reconcile ClusterRole")
+			clusterRole, err := r.reconcileRolloutsClusterRole(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify ClusterRole is created")
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).To(Succeed())
+
+			By("Reconcile Role.")
+			role, err := r.reconcileRolloutsRole(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify Role is created")
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(role), role)).To(Succeed())
+
+			By("Verify existing ClusterRole is deleted")
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).To(HaveOccurred())
+		})
+
+		It("Should delete existing RoleBinding when ClusterRoleBinding is reconciled", func() {
+
+			By("Reconcile RoleBinding")
+			sa, err := r.reconcileRolloutsServiceAccount(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+			role, err := r.reconcileRolloutsRole(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r.reconcileRolloutsRoleBinding(ctx, a, role, sa)).To(Succeed())
+
+			By("Verify RoleBinding is created")
+			roleBinding := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: DefaultArgoRolloutsResourceName, Namespace: a.Namespace}}
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(roleBinding), roleBinding)).To(Succeed())
+
+			By("Reconcile ClusterRoleBinding")
+			clusterRole, err := r.reconcileRolloutsClusterRole(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r.reconcileRolloutsClusterRoleBinding(ctx, clusterRole, sa, a)).To(Succeed())
+
+			By("Verify ClusterRoleBinding is created")
+			clusterRoleBinding := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: DefaultArgoRolloutsResourceName}}
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
+
+			By("Verify RoleBinding is deleted")
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(roleBinding), roleBinding)).To(HaveOccurred())
+		})
+
+		It("Should delete existing ClusterRoleBinding when RoleBinding is reconciled", func() {
+
+			By("Reconcile ClusterRoleBinding")
+			sa, err := r.reconcileRolloutsServiceAccount(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+			clusterRole, err := r.reconcileRolloutsClusterRole(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r.reconcileRolloutsClusterRoleBinding(ctx, clusterRole, sa, a)).To(Succeed())
+
+			By("Verify ClusterRoleBinding is created")
+			clusterRoleBinding := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: DefaultArgoRolloutsResourceName}}
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
+
+			By("Reconcile RoleBinding")
+			role, err := r.reconcileRolloutsRole(ctx, a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r.reconcileRolloutsRoleBinding(ctx, a, role, sa)).To(Succeed())
+
+			By("Verify RoleBinding is created")
+			roleBinding := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: DefaultArgoRolloutsResourceName, Namespace: a.Namespace}}
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(roleBinding), roleBinding)).To(Succeed())
+
+			By("Verify ClusterRoleBinding is deleted")
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).To(HaveOccurred())
+		})
+	})
 })
 
 func serviceMonitor() *monitoringv1.ServiceMonitor {

--- a/controllers/resources_test.go
+++ b/controllers/resources_test.go
@@ -1170,7 +1170,7 @@ var _ = Describe("Resource creation and cleanup tests", func() {
 			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).To(Succeed())
 
 			By("Verify existing Role is deleted")
-			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(role), role)).To(HaveOccurred())
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(role), role)).ToNot(Succeed())
 		})
 
 		It("Should delete existing ClusterRole when Role is reconciled", func() {
@@ -1190,7 +1190,7 @@ var _ = Describe("Resource creation and cleanup tests", func() {
 			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(role), role)).To(Succeed())
 
 			By("Verify existing ClusterRole is deleted")
-			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).To(HaveOccurred())
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).ToNot(Succeed())
 		})
 
 		It("Should delete existing RoleBinding when ClusterRoleBinding is reconciled", func() {
@@ -1216,7 +1216,7 @@ var _ = Describe("Resource creation and cleanup tests", func() {
 			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
 
 			By("Verify RoleBinding is deleted")
-			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(roleBinding), roleBinding)).To(HaveOccurred())
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(roleBinding), roleBinding)).ToNot(Succeed())
 		})
 
 		It("Should delete existing ClusterRoleBinding when RoleBinding is reconciled", func() {
@@ -1242,7 +1242,7 @@ var _ = Describe("Resource creation and cleanup tests", func() {
 			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(roleBinding), roleBinding)).To(Succeed())
 
 			By("Verify ClusterRoleBinding is deleted")
-			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).To(HaveOccurred())
+			Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole)).ToNot(Succeed())
 		})
 	})
 })

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -689,5 +689,100 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 			Expect(newPods.Items[0].Name).NotTo(Equal(oldPods.Items[0].Name)) // Ensure the Pod names are different
 		})
 
+		When("a namespace-scoped RolloutManager is installed into a namespace that previously contained a cluster-scoped RolloutManager, or vice versa", func() {
+
+			It("should cleanup any cluster/role/rolebinding resources that are present in the namespace, that do not match the current .spec.namespaceScoped value of the RolloutManager CR", func() {
+
+				var fakeRole rbacv1.Role
+				var fakeRoleBinding rbacv1.RoleBinding
+
+				var fakeClusterRole rbacv1.ClusterRole
+				var fakeClusterRoleBinding rbacv1.ClusterRoleBinding
+
+				By("creating ClusterRole/Binding in the namespace-scoped case, and Role/Binding in the cluster-scoped case")
+
+				if namespaceScopedParam {
+
+					fakeClusterRole = rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      controllers.DefaultArgoRolloutsResourceName,
+							Namespace: rolloutManager.Namespace,
+						},
+					}
+					Expect(k8sClient.Create(ctx, &fakeClusterRole)).To(Succeed())
+
+					fakeClusterRoleBinding = rbacv1.ClusterRoleBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      controllers.DefaultArgoRolloutsResourceName,
+							Namespace: rolloutManager.Namespace,
+						},
+						RoleRef: rbacv1.RoleRef{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "ClusterRole",
+							Name:     fakeClusterRole.Name,
+						},
+						Subjects: []rbacv1.Subject{
+							{
+								Kind:      rbacv1.ServiceAccountKind,
+								Name:      controllers.DefaultArgoRolloutsResourceName,
+								Namespace: rolloutManager.Namespace,
+							},
+						},
+					}
+					Expect(k8sClient.Create(ctx, &fakeClusterRoleBinding)).To(Succeed())
+
+				} else {
+
+					fakeRole = rbacv1.Role{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      controllers.DefaultArgoRolloutsResourceName,
+							Namespace: rolloutManager.Namespace,
+						},
+					}
+					Expect(k8sClient.Create(ctx, &fakeRole)).To(Succeed())
+
+					fakeRoleBinding = rbacv1.RoleBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      controllers.DefaultArgoRolloutsResourceName,
+							Namespace: rolloutManager.Namespace,
+						},
+						RoleRef: rbacv1.RoleRef{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Role",
+							Name:     fakeRole.Name,
+						},
+						Subjects: []rbacv1.Subject{
+							{
+								Kind:      rbacv1.ServiceAccountKind,
+								Name:      controllers.DefaultArgoRolloutsResourceName,
+								Namespace: rolloutManager.Namespace,
+							},
+						},
+					}
+					Expect(k8sClient.Create(ctx, &fakeRoleBinding)).To(Succeed())
+
+				}
+
+				By("creating RolloutManager and waiting for it to be available")
+				Expect(k8sClient.Create(ctx, &rolloutManager)).To(Succeed())
+				Eventually(rolloutManager, "1m", "1s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
+
+				if namespaceScopedParam {
+
+					By("verifying that in the namespace-scoped case, the cluster-scoped resources are deleted after reconciliation")
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&fakeClusterRole), &fakeClusterRole)).ToNot(Succeed())
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&fakeClusterRoleBinding), &fakeClusterRoleBinding)).ToNot(Succeed())
+
+				} else {
+
+					By("verifying that in the cluster-scoped case, the namespace-scoped resources are deleted after reconciliation")
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&fakeRole), &fakeRole)).ToNot(Succeed())
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&fakeRoleBinding), &fakeRoleBinding)).ToNot(Succeed())
+
+				}
+
+			})
+		})
+
 	})
 }


### PR DESCRIPTION
This PR is to delete RBAC resources while switching the scope of Rollouts instance. It means if user is switching from Cluster-scoped to namespace-scoped instance then we delete ClusterRole and ClusterRoleBinding created for cluster-scoped instance.