### PR TITLE
Fix race condition on metrics plugin E2E test

### DIFF
--- a/tests/e2e/fixture/k8s/fixture.go
+++ b/tests/e2e/fixture/k8s/fixture.go
@@ -29,7 +29,7 @@ func ExistByName(k8sClient client.Client) matcher.GomegaMatcher {
 	}, BeTrue())
 }
 
-// DoesNotExistByName checks if the given resource does not exist, when retrieving it by name/namespace.
+// NotExistByName checks if the given resource does not exist, when retrieving it by name/namespace.
 // Does NOT check if the resource content matches.
 func NotExistByName(k8sClient client.Client) matcher.GomegaMatcher {
 

--- a/tests/e2e/fixture/k8s/fixture.go
+++ b/tests/e2e/fixture/k8s/fixture.go
@@ -8,6 +8,8 @@ import (
 	matcher "github.com/onsi/gomega/types"
 	"k8s.io/client-go/util/retry"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,14 +29,26 @@ func ExistByName(k8sClient client.Client) matcher.GomegaMatcher {
 	}, BeTrue())
 }
 
+// DoesNotExistByName checks if the given resource does not exist, when retrieving it by name/namespace.
+// Does NOT check if the resource content matches.
+func NotExistByName(k8sClient client.Client) matcher.GomegaMatcher {
+
+	return WithTransform(func(k8sObject client.Object) bool {
+
+		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(k8sObject), k8sObject)
+		return apierrors.IsNotFound(err)
+	}, BeTrue())
+}
+
 // UpdateWithoutConflict will keep trying to update object until it succeeds, or times out.
 func UpdateWithoutConflict(ctx context.Context, obj client.Object, k8sClient client.Client, modify func(client.Object)) error {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Retrieve the latest version of the object
-		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 		if err != nil {
 			return err
 		}
+
 		modify(obj)
 
 		// Attempt to update the object


### PR DESCRIPTION
**What does this PR do / why we need it**:

Fix this intermittent error in metrics E2E test:

```
------------------------------
• [FAILED] [22.256 seconds]
Namespace-scoped RolloutManager tests RolloutManager tests - namespace-scoped [It] Should add, update, and remove traffic and metric plugins through RolloutManager CR
/home/runner/work/argo-rollouts-manager/argo-rollouts-manager/tests/e2e/rollout_tests_all.go:600

  Timeline >>
  STEP: Verify that RolloutManager is successfully created. @ 10/31/24 08:09:26.89
  STEP: Verify traffic and metric plugin is added to ConfigMap @ 10/31/24 08:09:38.014
  STEP: Update traffic and metric plugins @ 10/31/24 08:09:38.019
  STEP: Get existing Rollouts Pod(s) before update @ 10/31/24 08:09:38.022
  STEP: Verify traffic and metric plugin is updated in ConfigMap @ 10/31/24 08:09:38.04
  STEP: Remove traffic and metric plugins @ 10/31/24 08:09:38.042
  STEP: Remove plugins from RolloutManager CR @ 10/31/24 08:09:38.044
  STEP: Verify that traffic and metric plugins are removed from ConfigMap @ 10/31/24 08:09:38.057
  STEP: Get existing Rollouts Pod(s) after update @ 10/31/24 08:09:39.062
  STEP: Verify Rollouts Pod is restarted @ 10/31/24 08:09:39.066
  [FAILED] in [It] - /home/runner/work/argo-rollouts-manager/argo-rollouts-manager/tests/e2e/rollout_tests_all.go:687 @ 10/31/24 08:09:39.077
  << Timeline

  [FAILED] Expected
      <[]v1.Pod | len:2, cap:2>: [
          {
              TypeMeta: {Kind: "", APIVersion: ""},
              ObjectMeta: {
                  Name: "argo-rollouts-ddccf95db-bw89k",
                  GenerateName: "argo-rollouts-ddccf95db-",
                  Namespace: "argo-rollouts",
                  SelfLink: "",
                  UID: "bfc185e8-7e42-474b-ab00-49aacb898e1f",
                  ResourceVersion: "3729",


(...)

  to have length 1
  In [It] at: /home/runner/work/argo-rollouts-manager/argo-rollouts-manager/tests/e2e/rollout_tests_all.go:687 @ 10/31/24 08:09:39.077
------------------------------
```

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
Fixes #?

<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
