### PR TITLE
Refactor E2E test scripts: improve output and remove old step

### DIFF
--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -25,12 +25,7 @@ cd argo-rollouts
 git checkout $CURRENT_ROLLOUTS_VERSION
 go mod tidy
 
-# 2) Replace 'argoproj/rollouts-demo' image with 'quay.io/jgwest-redhat/rollouts-demo' in E2E tests
-# - The original 'argoproj/rollouts-demo' repository only has amd64 images, thus some of the E2E tests will not work on it.
-# - 'quay.io/jgwest-redhat/rollouts-demo' is based on the same code, but built for other archs
-find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/argoproj\/rollouts-demo/quay.io\/jgwest-redhat\/rollouts-demo/g'
-
-# 3) Setup the Namespace
+# 2) Setup the Namespace
 
 kubectl delete ns argo-rollouts || true
 
@@ -40,7 +35,7 @@ kubectl create ns argo-rollouts
 kubectl config set-context --current --namespace=argo-rollouts
 
 
-# 4) Build, install, and start the argo-rollouts-manager controller
+# 3) Build, install, and start the argo-rollouts-manager controller
 cd $SCRIPT_DIR/..
 
 
@@ -61,7 +56,7 @@ if [ -z "$SKIP_RUN_STEP" ]; then
   set -e
 fi
 
-# 5) Install Argo Rollouts into the Namespace via RolloutManager CR
+# 4) Install Argo Rollouts into the Namespace via RolloutManager CR
 
 cd $TMP_DIR/argo-rollouts
 
@@ -98,7 +93,7 @@ oc adm policy add-scc-to-user anyuid -z argo-rollouts -n argo-rollouts || true
 oc adm policy add-scc-to-user anyuid -z default -n argo-rollouts || true
 
 
-# 6) Run the E2E tests
+# 5) Run the E2E tests
 rm -f /tmp/test-e2e.log
 
 set +e
@@ -107,7 +102,7 @@ make test-e2e | tee /tmp/test-e2e.log
 
 set +x
 
-# 7) Check and report the results for unexpected failures
+# 6) Check and report the results for unexpected failures
 
 echo "-----------------------------------------------------------------"
 echo

--- a/hack/verify-rollouts-e2e-tests/main.go
+++ b/hack/verify-rollouts-e2e-tests/main.go
@@ -63,7 +63,7 @@ func main() {
 		return
 	}
 
-	// 3) Report unexpected failed tests, in alphabetical order
+	// 3a) Report unexpected failed tests, in alphabetical order
 	mapKeys := []string{}
 	for key := range testResults {
 		mapKeys = append(mapKeys, key)
@@ -75,6 +75,9 @@ func main() {
 		reportErrorAndExit(fmt.Errorf("no test results found"))
 		return
 	}
+
+	var testFailureOutput []string
+	var testSuccessOutput []string
 
 	atLeastOneTestPermFail := false
 
@@ -90,20 +93,36 @@ func main() {
 		for _, testRunLine := range testRuns {
 			if strings.Contains(testRunLine, "PASS") {
 				passFound = true
+				testSuccessOutput = append(testSuccessOutput, "Test passed - "+testName)
+				break
 			}
 		}
 
 		if !passFound {
-			fmt.Println("Unexpected test failure, test failed too many times - " + testName + ":")
-			for _, testRun := range testRuns {
-				fmt.Println(testRun)
-			}
 
-			fmt.Println()
+			testFailureOutput = append(testFailureOutput, "Unexpected test failure, test failed too many times - "+testName+":")
+
+			testFailureOutput = append(testFailureOutput, testRuns...)
+
+			testFailureOutput = append(testFailureOutput, "")
 			atLeastOneTestPermFail = true
 
 		}
 
+	}
+
+	fmt.Println()
+
+	// 3b) First print successes
+	for _, line := range testSuccessOutput {
+		fmt.Println(line)
+	}
+
+	fmt.Println()
+
+	// 3c) Then print failures
+	for _, line := range testFailureOutput {
+		fmt.Println(line)
 	}
 
 	// 4) Exit with error code 1 if there was at least one unexpected test failure.


### PR DESCRIPTION
**What does this PR do / why we need it**:
- We no longer need to use the 'jgwest-redhat/rollouts-demo' image, now that we've moved to nginx-unprivileged, so this step can be removed.
- Add additional steps to upstream test output

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**How to test changes / Special notes to the reviewer**:
N/A