### PR TITLE
Upgrade to Argo Rollouts v1.8.0

### DIFF
--- a/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-27T12:15:43Z"
+    createdAt: "2025-02-03T12:24:05Z"
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: argo-rollouts-manager.v0.0.1

--- a/bundle/manifests/argoproj.io_analysisruns.yaml
+++ b/bundle/manifests/argoproj.io_analysisruns.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: analysisruns.argoproj.io
 spec:
@@ -94,6 +94,11 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -207,6 +212,13 @@ spec:
                               type: object
                             query:
                               type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3015,6 +3027,9 @@ spec:
                               type: string
                             query:
                               type: string
+                            timeout:
+                              format: int64
+                              type: integer
                           required:
                           - query
                           type: object
@@ -3066,6 +3081,15 @@ spec:
                               type: boolean
                             query:
                               type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
                             timeout:
                               format: int64
                               type: integer
@@ -3198,6 +3222,9 @@ spec:
                 items:
                   properties:
                     consecutiveError:
+                      format: int32
+                      type: integer
+                    consecutiveSuccess:
                       format: int32
                       type: integer
                     count:

--- a/bundle/manifests/argoproj.io_analysistemplates.yaml
+++ b/bundle/manifests/argoproj.io_analysistemplates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: analysistemplates.argoproj.io
 spec:
@@ -90,6 +90,11 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -203,6 +208,13 @@ spec:
                               type: object
                             query:
                               type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3011,6 +3023,9 @@ spec:
                               type: string
                             query:
                               type: string
+                            timeout:
+                              format: int64
+                              type: integer
                           required:
                           - query
                           type: object
@@ -3062,6 +3077,15 @@ spec:
                               type: boolean
                             query:
                               type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
                             timeout:
                               format: int64
                               type: integer

--- a/bundle/manifests/argoproj.io_clusteranalysistemplates.yaml
+++ b/bundle/manifests/argoproj.io_clusteranalysistemplates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: clusteranalysistemplates.argoproj.io
 spec:
@@ -90,6 +90,11 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -203,6 +208,13 @@ spec:
                               type: object
                             query:
                               type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3011,6 +3023,9 @@ spec:
                               type: string
                             query:
                               type: string
+                            timeout:
+                              format: int64
+                              type: integer
                           required:
                           - query
                           type: object
@@ -3062,6 +3077,15 @@ spec:
                               type: boolean
                             query:
                               type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
                             timeout:
                               format: int64
                               type: integer

--- a/bundle/manifests/argoproj.io_experiments.yaml
+++ b/bundle/manifests/argoproj.io_experiments.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: experiments.argoproj.io
 spec:

--- a/bundle/manifests/argoproj.io_rollouts.yaml
+++ b/bundle/manifests/argoproj.io_rollouts.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: rollouts.argoproj.io
 spec:
@@ -662,6 +662,16 @@ spec:
                                   - type: string
                                   x-kubernetes-int-or-string: true
                               type: object
+                            plugin:
+                              properties:
+                                config:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
                             setCanaryScale:
                               properties:
                                 matchTrafficWeight:
@@ -934,6 +944,10 @@ spec:
                                 type: object
                               annotationPrefix:
                                 type: string
+                              canaryIngressAnnotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
                               stableIngress:
                                 type: string
                               stableIngresses:
@@ -3717,6 +3731,45 @@ spec:
                     type: object
                   stablePingPong:
                     type: string
+                  stepPluginStatuses:
+                    items:
+                      properties:
+                        backoff:
+                          type: string
+                        disabled:
+                          type: boolean
+                        executions:
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          format: date-time
+                          type: string
+                        index:
+                          format: int32
+                          type: integer
+                        message:
+                          type: string
+                        name:
+                          type: string
+                        operation:
+                          type: string
+                        phase:
+                          type: string
+                        startedAt:
+                          format: date-time
+                          type: string
+                        status:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        updatedAt:
+                          format: date-time
+                          type: string
+                      required:
+                      - index
+                      - name
+                      - operation
+                      type: object
+                    type: array
                   weights:
                     properties:
                       additional:

--- a/config/crd/bases/analysis-run-crd.yaml
+++ b/config/crd/bases/analysis-run-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: analysisruns.argoproj.io
 spec:
   group: argoproj.io
@@ -94,6 +94,11 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -207,6 +212,13 @@ spec:
                               type: object
                             query:
                               type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3015,6 +3027,9 @@ spec:
                               type: string
                             query:
                               type: string
+                            timeout:
+                              format: int64
+                              type: integer
                           required:
                           - query
                           type: object
@@ -3066,6 +3081,15 @@ spec:
                               type: boolean
                             query:
                               type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
                             timeout:
                               format: int64
                               type: integer
@@ -3198,6 +3222,9 @@ spec:
                 items:
                   properties:
                     consecutiveError:
+                      format: int32
+                      type: integer
+                    consecutiveSuccess:
                       format: int32
                       type: integer
                     count:

--- a/config/crd/bases/analysis-template-crd.yaml
+++ b/config/crd/bases/analysis-template-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: analysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -90,6 +90,11 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -203,6 +208,13 @@ spec:
                               type: object
                             query:
                               type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3011,6 +3023,9 @@ spec:
                               type: string
                             query:
                               type: string
+                            timeout:
+                              format: int64
+                              type: integer
                           required:
                           - query
                           type: object
@@ -3062,6 +3077,15 @@ spec:
                               type: boolean
                             query:
                               type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
                             timeout:
                               format: int64
                               type: integer

--- a/config/crd/bases/cluster-analysis-template-crd.yaml
+++ b/config/crd/bases/cluster-analysis-template-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clusteranalysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -90,6 +90,11 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -203,6 +208,13 @@ spec:
                               type: object
                             query:
                               type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3011,6 +3023,9 @@ spec:
                               type: string
                             query:
                               type: string
+                            timeout:
+                              format: int64
+                              type: integer
                           required:
                           - query
                           type: object
@@ -3062,6 +3077,15 @@ spec:
                               type: boolean
                             query:
                               type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
                             timeout:
                               format: int64
                               type: integer

--- a/config/crd/bases/experiment-crd.yaml
+++ b/config/crd/bases/experiment-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: experiments.argoproj.io
 spec:
   group: argoproj.io

--- a/config/crd/bases/rollout-crd.yaml
+++ b/config/crd/bases/rollout-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: rollouts.argoproj.io
 spec:
   group: argoproj.io
@@ -662,6 +662,16 @@ spec:
                                   - type: string
                                   x-kubernetes-int-or-string: true
                               type: object
+                            plugin:
+                              properties:
+                                config:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
                             setCanaryScale:
                               properties:
                                 matchTrafficWeight:
@@ -934,6 +944,10 @@ spec:
                                 type: object
                               annotationPrefix:
                                 type: string
+                              canaryIngressAnnotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
                               stableIngress:
                                 type: string
                               stableIngresses:
@@ -3717,6 +3731,45 @@ spec:
                     type: object
                   stablePingPong:
                     type: string
+                  stepPluginStatuses:
+                    items:
+                      properties:
+                        backoff:
+                          type: string
+                        disabled:
+                          type: boolean
+                        executions:
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          format: date-time
+                          type: string
+                        index:
+                          format: int32
+                          type: integer
+                        message:
+                          type: string
+                        name:
+                          type: string
+                        operation:
+                          type: string
+                        phase:
+                          type: string
+                        startedAt:
+                          format: date-time
+                          type: string
+                        status:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        updatedAt:
+                          format: date-time
+                          type: string
+                      required:
+                      - index
+                      - name
+                      - operation
+                      type: object
+                    type: array
                   weights:
                     properties:
                       additional:

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -12,7 +12,7 @@ const (
 	DefaultArgoRolloutsImage = "quay.io/argoproj/argo-rollouts"
 
 	// ArgoRolloutsDefaultVersion is the default version for the Rollouts controller.
-	DefaultArgoRolloutsVersion = "v1.7.2" // v1.7.2
+	DefaultArgoRolloutsVersion = "v1.8.0" // v1.8.0
 
 	// DefaultArgoRolloutsResourceName is the default name for Rollouts controller resources such as
 	// deployment, service, role, rolebinding and serviceaccount.

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -178,7 +178,7 @@ sanity_test_metrics_data() {
 
   fi
 
-  if [[ "`expr $DELTA_ERROR_RECONCILES \> 60`" == "1" ]]; then
+  if [[ "`expr $DELTA_ERROR_RECONCILES \> 70`" == "1" ]]; then
     # This value is arbitrary, and should be updated if at any point it becomes inaccurate (but first audit the test/code to make sure it is not an actual product/test issue, before increasing)
     echo "Number of Reconcile calls that returned an error '$DELTA_ERROR_RECONCILES' was greater than the expected value"
     exit 1

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -211,7 +211,7 @@ if [ -f "/tmp/e2e-operator-run.log" ]; then
 
   set +u # allow undefined vars
 
-  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled"`
+  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled" | grep -v "failed to reconcile Rollout's ClusterRoleBinding" | grep -v "clusterrolebindings.rbac.authorization.k8s.io \"argo-rollouts\" already exists"`
 
   if [ "$UNEXPECTED_ERRORS_FOUND_TEXT" != "" ]; then
   

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CURRENT_ROLLOUTS_VERSION=v1.7.2
+CURRENT_ROLLOUTS_VERSION=v1.8.0
 
 function cleanup {
   echo "* Cleaning up"
@@ -122,6 +122,7 @@ set -e
 "$SCRIPT_DIR/verify-rollouts-e2e-tests/verify-e2e-test-results.sh" /tmp/test-e2e.log
 
 echo "* SUCCESS: No unexpected errors occurred."
+
 
 
 

--- a/hack/verify-rollouts-e2e-tests/main.go
+++ b/hack/verify-rollouts-e2e-tests/main.go
@@ -182,7 +182,17 @@ func parseTestResultsFromFile(fileContents []string, testsExpectedToFailList []s
 				continue
 			}
 
-			testName = line[strings.Index(line, ".")+1 : roundBraceIndex-1]
+			dotIndex := strings.Index(line, ".")
+			if dotIndex == -1 {
+				continue
+			}
+
+			if dotIndex+1 >= roundBraceIndex-1 {
+				fmt.Println("Unexpected line format: [", line, "]")
+				continue
+			}
+
+			testName = line[dotIndex+1 : roundBraceIndex-1]
 			atLeastOnePassSeen = true
 
 		} else {

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -609,7 +609,7 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 						TrafficManagement: []rolloutsmanagerv1alpha1.Plugin{
 							{
 								Name:     "argoproj-labs/gatewayAPI",
-								Location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gateway-api-plugin-linux-amd64"},
+								Location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-amd64"},
 						},
 						Metric: []rolloutsmanagerv1alpha1.Plugin{
 							{

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -609,7 +609,9 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 						TrafficManagement: []rolloutsmanagerv1alpha1.Plugin{
 							{
 								Name:     "argoproj-labs/gatewayAPI",
-								Location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-amd64"},
+								Location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-amd64",
+								SHA256:   "d00ce783dc0eb30ac2e203bdfdac5300a4b47695267a7fa57474e0a4a7376afe",
+							},
 						},
 						Metric: []rolloutsmanagerv1alpha1.Plugin{
 							{


### PR DESCRIPTION
Update to latest release of Argo Rollouts: https://github.com/argoproj/argo-rollouts/releases/tag/v1.8.0
Before merging this PR, ensure you check the Argo Rollouts change logs and release notes: 
- Ensure there are no changes to the Argo Rollouts install YAML that we need to respond to with changes in the operator
    - You can do this by downloading the 'install.yaml' from both the previous version (for example, v1.7.1) and new version (for example, v1.7.2), and then comparing them using a tool like [Meld](https://gitlab.gnome.org/GNOME/meld) or diff.
	- If there are changes to resources like Deployments and Roles in the install.yaml between the two versions, this will likely require a corresponding code change within the operator. e.g. a new permission added to a Role would require a change to the Role creation code in the operator.
- Ensure there are no backwards incompatible API/behaviour changes in the change logs