### PR TITLE
Use multiarch/no privilege nginx-unprivileged image for E2E Tests

### DIFF
--- a/tests/e2e/fixture/rollouts/fixture.go
+++ b/tests/e2e/fixture/rollouts/fixture.go
@@ -44,7 +44,7 @@ spec:
       containers:
         # based on docker.io/kostiscodefresh/gitops-canary-app:v1.0
         # mirrored to jgwest-redhat
-      - image: quay.io/jgwest-redhat/gitops-canary-app@sha256:4fdd3483fa119b413aa9e3c4459bfa2be399c0741ab7565d2a716e362fc1aa41
+      - image: nginxinc/nginx-unprivileged@sha256:0569e319d06556564ad40882ed35231461d06bec788b5aec00b83b6e9f3ced1a
         name: webserver-simple
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**What does this PR do / why we need it**:
- This switches 0.0.4 branch to use an E2E test container image which is:
    - Multi-arch
    - Requires no special privileges (allowing it to run on OpenShift with default SCC)
- This fix is already on `main` branch, this PR backports it to 0.0.4