### PR TITLE
Re-enable fix for multi-arch Argo Rollouts E2E test images

### DIFF
--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -25,7 +25,12 @@ cd argo-rollouts
 git checkout $CURRENT_ROLLOUTS_VERSION
 go mod tidy
 
-# 2) Setup the Namespace
+# 2) Replace 'argoproj/rollouts-demo' image with 'quay.io/jgwest-redhat/rollouts-demo' in upstream E2E tests
+# - The original 'argoproj/rollouts-demo' repository only has amd64 images, thus some of the E2E tests will not work on Power/Z.
+# - 'quay.io/jgwest-redhat/rollouts-demo' is based on the same code, but built for other archs
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/argoproj\/rollouts-demo/quay.io\/jgwest-redhat\/rollouts-demo/g'
+
+# 3) Setup the Namespace
 
 kubectl delete ns argo-rollouts || true
 
@@ -35,7 +40,7 @@ kubectl create ns argo-rollouts
 kubectl config set-context --current --namespace=argo-rollouts
 
 
-# 3) Build, install, and start the argo-rollouts-manager controller
+# 4) Build, install, and start the argo-rollouts-manager controller
 cd $SCRIPT_DIR/..
 
 
@@ -56,7 +61,7 @@ if [ -z "$SKIP_RUN_STEP" ]; then
   set -e
 fi
 
-# 4) Install Argo Rollouts into the Namespace via RolloutManager CR
+# 5) Install Argo Rollouts into the Namespace via RolloutManager CR
 
 cd $TMP_DIR/argo-rollouts
 
@@ -93,7 +98,7 @@ oc adm policy add-scc-to-user anyuid -z argo-rollouts -n argo-rollouts || true
 oc adm policy add-scc-to-user anyuid -z default -n argo-rollouts || true
 
 
-# 5) Run the E2E tests
+# 6) Run the E2E tests
 rm -f /tmp/test-e2e.log
 
 set +e
@@ -102,7 +107,7 @@ make test-e2e | tee /tmp/test-e2e.log
 
 set +x
 
-# 6) Check and report the results for unexpected failures
+# 7) Check and report the results for unexpected failures
 
 echo "-----------------------------------------------------------------"
 echo


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Backport [this fix](https://github.com/argoproj-labs/argo-rollouts-manager/pull/109) to `release-0.0.5` branch

