### PR TITLE
Upgrade to Argo Rollouts v1.8.2

### DIFF
--- a/controllers/default.go
+++ b/controllers/default.go
@@ -12,7 +12,7 @@ const (
 	DefaultArgoRolloutsImage = "quay.io/argoproj/argo-rollouts"
 
 	// ArgoRolloutsDefaultVersion is the default version for the Rollouts controller.
-	DefaultArgoRolloutsVersion = "v1.8.0" // v1.8.0
+	DefaultArgoRolloutsVersion = "v1.8.2" // v1.8.2
 
 	// DefaultArgoRolloutsResourceName is the default name for Rollouts controller resources such as
 	// deployment, service, role, rolebinding and serviceaccount.

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CURRENT_ROLLOUTS_VERSION=v1.8.0
+CURRENT_ROLLOUTS_VERSION=v1.8.2
 
 function cleanup {
   echo "* Cleaning up"
@@ -127,6 +127,7 @@ set -e
 "$SCRIPT_DIR/verify-rollouts-e2e-tests/verify-e2e-test-results.sh" /tmp/test-e2e.log
 
 echo "* SUCCESS: No unexpected errors occurred."
+
 
 
 

--- a/tests/e2e/cluster-scoped/cluster_scoped_rollouts_test.go
+++ b/tests/e2e/cluster-scoped/cluster_scoped_rollouts_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Cluster-scoped RolloutManager tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify that RolloutManager is successfully created.")
-			Eventually(rolloutsManager, "1m", "1s").Should(rmFixture.HavePhase(rmv1alpha1.PhaseAvailable))
+			Eventually(rolloutsManager, "4m", "1s").Should(rmFixture.HavePhase(rmv1alpha1.PhaseAvailable))
 
 			By("Verify that Status.Condition is having success condition.")
 			Eventually(rolloutsManager, "1m", "1s").Should(rmFixture.HaveSuccessCondition())
@@ -385,9 +385,9 @@ var _ = Describe("Cluster-scoped RolloutManager tests", func() {
 			Expect(k8sClient.Delete(ctx, &rolloutsManagerCl)).To(Succeed())
 
 			By("Verify clusterRole '*aggregate*' is deleted")
-			Eventually(clusterRoleAdmin, "1m", "1s").ShouldNot((k8s.ExistByName(k8sClient)))
-			Eventually(clusterRoleView, "1m", "1s").ShouldNot((k8s.ExistByName(k8sClient)))
-			Eventually(clusterRoleEdit, "1m", "1s").ShouldNot((k8s.ExistByName(k8sClient)))
+			Eventually(clusterRoleAdmin, "1m", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+			Eventually(clusterRoleView, "1m", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+			Eventually(clusterRoleEdit, "1m", "1s").ShouldNot(k8s.ExistByName(k8sClient))
 
 		})
 	})


### PR DESCRIPTION
Before merging this PR, ensure you check the Argo Rollouts change logs and release notes: 
- Ensure there are no changes to the Argo Rollouts install YAML that we need to respond to with changes in the operator
	- You can do this by downloading the 'install.yaml' from both the previous version (for example, v1.7.1) and new version (for example, v1.7.2), and then comparing them using a tool like [Meld](https://gitlab.gnome.org/GNOME/meld) or diff.
	- If there are changes to resources like Deployments and Roles in the install.yaml between the two versions, this will likely require a corresponding code change within the operator. e.g. a new permission added to a Role would require a change to the Role creation code in the operator.
- Ensure there are no backwards incompatible API/behaviour changes in the change logs
