### PR TITLE
Switch to using wildcard to match expected error in E2E script

### DIFF
--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -219,7 +219,7 @@ if [ -f "/tmp/e2e-operator-run.log" ]; then
   # Grep the log for unexpected errors
   # - Ignore errors that are expected to occur
 
-  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled" | grep -v "failed to reconcile Rollout's ClusterRoleBinding" | grep -v "clusterrolebindings.rbac.authorization.k8s.io \"argo-rollouts\" already exists"`
+  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled" | grep -v "failed to reconcile Rollout's ClusterRoleBinding" | grep -v "clusterrolebindings.rbac.authorization.k8s.io.*argo-rollouts.*already.*exists"`
 
   if [ "$UNEXPECTED_ERRORS_FOUND_TEXT" != "" ]; then
   

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -219,7 +219,7 @@ if [ -f "/tmp/e2e-operator-run.log" ]; then
   # Grep the log for unexpected errors
   # - Ignore errors that are expected to occur
 
-  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled" | grep -v "failed to reconcile Rollout's ClusterRoleBinding" | grep -v "clusterrolebindings.rbac.authorization.k8s.io.*argo-rollouts.*already.*exists"`
+  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled" | grep -v "failed to reconcile Rollout's ClusterRoleBinding" | grep -v "clusterrolebindings.rbac.authorization.k8s.io.*argo-rollouts.*already.*exists" | grep -v "servicemonitors.monitoring.coreos.com.*argo-rollouts.*already.*exists"`
 
   if [ "$UNEXPECTED_ERRORS_FOUND_TEXT" != "" ]; then
   


### PR DESCRIPTION
**What does this PR do / why we need it**:
- I previously noticed that an expected error was not being filtered by our 'unexpected errors check'
```
2025-06-11T23:40:12Z ERROR Reconciler error '{"controller":' '"rolloutmanager",' '"controllerGroup":' '"argoproj.io",' '"controllerKind":' '"RolloutManager",' '"RolloutManager":' '{"name":"test-rollouts-manager-2","namespace":"argo-rollouts"},' '"namespace":' '"argo-rollouts",' '"name":' '"test-rollouts-manager-2",' '"reconcileID":' '"2794f12c-8cef-4892-ba2a-6e154a8fdb32",' '"error":' '"clusterrolebindings.rbac.authorization.k8s.io' '\"argo-rollouts\"' already 'exists"}'
```
- Grepping out this error is difficult due to use of `' " \` characters, so I've just switched to using simple regexp to ignore that punctuation.


