### PR TITLE
Backport E2E test fixes to 'release-0.0.5' branch

### DIFF
--- a/.github/workflows/rollouts_e2e_tests.yml
+++ b/.github/workflows/rollouts_e2e_tests.yml
@@ -15,11 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
+      fail-fast: false
       matrix:
-        k3s-version: [ v1.28.2 ]
-        # k3s-version: [ v1.28.2, v1.27.6, v1.26.9 ]
+        kubernetes:
+          - version: '1.28'
+            latest: false
     steps:
       - name: Install K3S
+        env:
+          INSTALL_K3S_CHANNEL: v${{ matrix.kubernetes.version }}      
         run: |
           set -x
           curl -sfL https://get.k3s.io | sh -

--- a/hack/run-rollouts-manager-e2e-tests.sh
+++ b/hack/run-rollouts-manager-e2e-tests.sh
@@ -60,7 +60,7 @@ if [ -f "/tmp/e2e-operator-run.log" ]; then
 
   set +u # allow undefined vars
 
-  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled" | grep -v "failed to reconcile Rollout's ClusterRoleBinding" | grep -v "clusterrolebindings.rbac.authorization.k8s.io \"argo-rollouts\" already exists"`
+  UNEXPECTED_ERRORS_FOUND_TEXT=`cat /tmp/e2e-operator-run.log | grep "ERROR" | grep -v "because it is being terminated" | grep -v "the object has been modified; please apply your changes to the latest version and try again" | grep -v "unable to fetch" | grep -v "StorageError" | grep -v "client rate limiter Wait returned an error: context canceled" | grep -v "failed to reconcile Rollout's ClusterRoleBinding" | grep -v "clusterrolebindings.rbac.authorization.k8s.io.*argo-rollouts.*already.*exists" | grep -v "servicemonitors.monitoring.coreos.com.*argo-rollouts.*already.*exists"`
 
   if [ "$UNEXPECTED_ERRORS_FOUND_TEXT" != "" ]; then
   

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -25,10 +25,27 @@ cd argo-rollouts
 git checkout $CURRENT_ROLLOUTS_VERSION
 go mod tidy
 
-# 2) Replace 'argoproj/rollouts-demo' image with 'quay.io/jgwest-redhat/rollouts-demo' in upstream E2E tests
+# 2a) Replace 'argoproj/rollouts-demo' image with 'quay.io/jgwest-redhat/rollouts-demo' in upstream E2E tests
 # - The original 'argoproj/rollouts-demo' repository only has amd64 images, thus some of the E2E tests will not work on Power/Z.
 # - 'quay.io/jgwest-redhat/rollouts-demo' is based on the same code, but built for other archs
 find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/argoproj\/rollouts-demo/quay.io\/jgwest-redhat\/rollouts-demo/g'
+
+# 2b) Replace nginx images used by E2E tests with images from quay.io (thus no rate limiting) 
+
+# quay.io/jgwest-redhat/nginx@sha256:07ab71a2c8e4ecb19a5a5abcfb3a4f175946c001c8af288b1aa766d67b0d05d2 is a copy of nginx:1.19-alpine
+
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/nginx:1.19-alpine/quay.io\/jgwest-redhat\/nginx@sha256:07ab71a2c8e4ecb19a5a5abcfb3a4f175946c001c8af288b1aa766d67b0d05d2/g'
+
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/nginx:1.14.2/quay.io\/jgwest-redhat\/nginx@sha256:07ab71a2c8e4ecb19a5a5abcfb3a4f175946c001c8af288b1aa766d67b0d05d2/g'
+
+# 2c) replace the rollouts-pod-template-hash of 'TestCanaryDynamicStableScale', since we have updated the image above
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/868d98995b/5496d694d6/g'
+
+# replace the TestCanaryScaleDownOnAbort and TestCanaryScaleDownOnAbortNoTrafficRouting, for same reason
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/66597877b7/6fcb5674b5/g'
+
+
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f -name "*.bak" -delete
 
 # 3) Setup the Namespace
 
@@ -127,7 +144,4 @@ set -e
 "$SCRIPT_DIR/verify-rollouts-e2e-tests/verify-e2e-test-results.sh" /tmp/test-e2e.log
 
 echo "* SUCCESS: No unexpected errors occurred."
-
-
-
 


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Backport E2E test fixes to 'release-0.0.5' branch
- E2E test fixes are primarily around moving images from docker hub to quay.io