### PR TITLE
Fix simple race condition in traffic metric/plugin E2E test

### DIFF
--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -626,7 +626,7 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 			Expect(k8sClient.Create(ctx, &rolloutsManager)).To(Succeed())
 
 			By("Verify that RolloutManager is successfully created.")
-			Eventually(rolloutsManager, "1m", "1s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
+			Eventually(rolloutsManager, "4m", "5s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
 
 			By("Verify traffic and metric plugin is added to ConfigMap")
 			configMap := corev1.ConfigMap{
@@ -650,8 +650,8 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 			Expect(k8sClient.List(ctx, &oldPods, client.InNamespace(rolloutsManager.Namespace), client.MatchingLabels{"app.kubernetes.io/name": "argo-rollouts"})).To(Succeed())
 			Expect(oldPods.Items).To(HaveLen(1))
 
+			By("Update RolloutManager CR to use placeholder values, so we can verify ConfigMap is updated")
 			Expect(k8sClient.Update(ctx, &rolloutsManager)).To(Succeed())
-			Eventually(rolloutsManager, "1m", "1s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
 
 			By("Verify traffic and metric plugin is updated in ConfigMap")
 			Eventually(func() bool {


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Fix simple race condition in traffic metric/plugin E2E test

Failing case looks like this within Argo Rollouts Pod:
```
[jgw@localhost-lan argo-rollouts-manager]$ k logs pod/argo-rollouts-c854d44bc-ftlss
time="2025-07-31T02:43:31Z" level=info msg="Argo Rollouts starting" version=vv1.8.3+49fa151
time="2025-07-31T02:43:31Z" level=info msg="Creating event broadcaster"
time="2025-07-31T02:43:31Z" level=info msg="Setting up event handlers"
time="2025-07-31T02:43:31Z" level=info msg="Setting up experiments event handlers"
time="2025-07-31T02:43:31Z" level=info msg="Setting up analysis event handlers"
time="2025-07-31T02:43:31Z" level=info msg="Downloading plugin argoproj-labs/gatewayAPI from: https://test-update-traffic-plugin"
time="2025-07-31T02:43:31Z" level=fatal msg="Failed to download plugins: failed to download plugin from https://test-update-traffic-plugin: failed to download file from https://test-update-traffic-plugin: Get \"https://test-update-traffic-plugin\": dial tcp: lookup test-update-traffic-plugin on 172.30.0.10:53: no such host"
```

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**How to test changes / Special notes to the reviewer**:
