### PR TITLE
Add the support for custom labels for resources created by ArgoRolloutManager

### DIFF
--- a/controllers/argorollouts_controller.go
+++ b/controllers/argorollouts_controller.go
@@ -47,10 +47,10 @@ type RolloutManagerReconciler struct {
 	client.Client
 	Scheme                       *runtime.Scheme
 	OpenShiftRoutePluginLocation string
-	//ArgoRolloutsCustumLabel is used to set custom labels on Argo Rollouts resources
+	//ResourceLabels is used to set custom labels on Argo Rollouts resources
 	// This is used to set the label on the ConfigMap and Secrets created by the controller for now.
 	// The label is used to identify the resources created by the RolloutManager.
-	ArgoRolloutsCustomLabel map[string]string
+	ResourceLabels map[string]string
 
 	// NamespaceScopedArgoRolloutsController is used to configure scope of Argo Rollouts controller
 	// If value is true then deploy namespace-scoped Argo Rollouts controller else cluster-scoped

--- a/controllers/argorollouts_controller.go
+++ b/controllers/argorollouts_controller.go
@@ -47,6 +47,10 @@ type RolloutManagerReconciler struct {
 	client.Client
 	Scheme                       *runtime.Scheme
 	OpenShiftRoutePluginLocation string
+	//ArgoRolloutsCustumLabel is used to set custom labels on Argo Rollouts resources
+	// This is used to set the label on the ConfigMap and Secrets created by the controller for now.
+	// The label is used to identify the resources created by the RolloutManager.
+	ArgoRolloutsCustomLabel map[string]string
 
 	// NamespaceScopedArgoRolloutsController is used to configure scope of Argo Rollouts controller
 	// If value is true then deploy namespace-scoped Argo Rollouts controller else cluster-scoped

--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -41,8 +41,8 @@ func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr ro
 	}
 
 	setRolloutsLabelsAndAnnotationsToObject(&desiredConfigMap.ObjectMeta, cr)
-	if r.ArgoRolloutsCustomLabel != nil {
-		setCustomLabels(&desiredConfigMap.ObjectMeta, r.ArgoRolloutsCustomLabel)
+	if r.ResourceLabels != nil {
+		setCustomLabels(&desiredConfigMap.ObjectMeta, r.ResourceLabels)
 	}
 
 	trafficRouterPluginsMap := map[string]pluginItem{

--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -41,6 +41,9 @@ func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr ro
 	}
 
 	setRolloutsLabelsAndAnnotationsToObject(&desiredConfigMap.ObjectMeta, cr)
+	if r.ArgoRolloutsCustomLabel != nil {
+		setCustomLabels(&desiredConfigMap.ObjectMeta, r.ArgoRolloutsCustomLabel)
+	}
 
 	trafficRouterPluginsMap := map[string]pluginItem{
 		OpenShiftRolloutPluginName: {

--- a/controllers/configmap_test.go
+++ b/controllers/configmap_test.go
@@ -76,6 +76,9 @@ var _ = Describe("ConfigMap Test", func() {
 	})
 
 	It("verifies that the custom labels are added to the ConfigMap", func() {
+		r = makeTestReconcilerWithCustomLabels(map[string]string{
+			"custom1": "value",
+		}, &a)
 		expectedConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: DefaultRolloutsConfigMapName,

--- a/controllers/configmap_test.go
+++ b/controllers/configmap_test.go
@@ -75,6 +75,37 @@ var _ = Describe("ConfigMap Test", func() {
 
 	})
 
+	It("verifies that the custom labels are added to the ConfigMap", func() {
+		expectedConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: DefaultRolloutsConfigMapName,
+				Labels: map[string]string{
+					"custom1":                     "value",
+					"app.kubernetes.io/component": DefaultArgoRolloutsResourceName,
+					"app.kubernetes.io/name":      DefaultArgoRolloutsResourceName,
+					"app.kubernetes.io/part-of":   DefaultArgoRolloutsResourceName,
+				},
+			},
+		}
+
+		By("Call reconcileConfigMap")
+		Expect(r.reconcileConfigMap(ctx, a)).To(Succeed())
+
+		By("Verify that the fetched ConfigMap matches the desired one")
+
+		fetchedConfigMap := &corev1.ConfigMap{}
+		Expect(fetchObject(ctx, r.Client, a.Namespace, expectedConfigMap.Name, fetchedConfigMap)).To(Succeed())
+
+		Expect(fetchedConfigMap.Labels).To(Equal(expectedConfigMap.Labels))
+
+		By("Call reconcileConfigMap again")
+		Expect(r.reconcileConfigMap(ctx, a)).To(Succeed())
+
+		By("verifying that the data is still present")
+		Expect(fetchedConfigMap.Labels).To(Equal(expectedConfigMap.Labels))
+
+	})
+
 	It("verifies traffic and metric plugin creation/modification and ensures OpenShiftRolloutPlugin existence", func() {
 		By("Add a pod that matches the deployment's selector")
 		addTestPodToFakeClient(r, a.Namespace, existingDeployment)

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -736,8 +736,8 @@ func (r *RolloutManagerReconciler) reconcileRolloutsSecrets(ctx context.Context,
 	}
 
 	setRolloutsLabelsAndAnnotationsToObject(&expectedSecret.ObjectMeta, cr)
-	if r.ArgoRolloutsCustomLabel != nil {
-		setCustomLabels(&expectedSecret.ObjectMeta, r.ArgoRolloutsCustomLabel)
+	if r.ResourceLabels != nil {
+		setCustomLabels(&expectedSecret.ObjectMeta, r.ResourceLabels)
 	}
 
 	// If the Secret doesn't exist (or an unrelated error occurred)....

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -736,6 +736,9 @@ func (r *RolloutManagerReconciler) reconcileRolloutsSecrets(ctx context.Context,
 	}
 
 	setRolloutsLabelsAndAnnotationsToObject(&expectedSecret.ObjectMeta, cr)
+	if r.ArgoRolloutsCustomLabel != nil {
+		setCustomLabels(&expectedSecret.ObjectMeta, r.ArgoRolloutsCustomLabel)
+	}
 
 	// If the Secret doesn't exist (or an unrelated error occurred)....
 	liveSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: expectedSecret.Name, Namespace: expectedSecret.Namespace}}

--- a/controllers/resources_test.go
+++ b/controllers/resources_test.go
@@ -538,6 +538,26 @@ var _ = Describe("Resource creation and cleanup tests", func() {
 			Expect(secret.ObjectMeta.Annotations["keyannotation"]).To(Equal(a.Spec.AdditionalMetadata.Annotations["keyannotation"]))
 		})
 
+		It("Test for Custom Labels for secrets created by Rollouts Manager function", func() {
+			Expect(r.reconcileRolloutsSecrets(ctx, a)).To(Succeed())
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DefaultRolloutsNotificationSecretName,
+					Namespace: a.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "argo-rollouts",
+						"app.kubernetes.io/name":      "argo-rollouts",
+						"app.kubernetes.io/part-of":   "argo-rollouts",
+						"custom1":                     "value",
+						"keylabel":                    "valuelabel",
+					},
+				},
+			}
+			fetchedSecret := &corev1.Secret{}
+			Expect(fetchObject(ctx, r.Client, a.Namespace, secret.Name, fetchedSecret)).To(Succeed())
+			Expect(fetchedSecret.ObjectMeta.Labels).To(Equal(secret.ObjectMeta.Labels))
+		})
+
 		It("test for removeClusterScopedResourcesIfApplicable function", func() {
 
 			By("creating default cluster-scoped ClusterRole/ClusterRoleBinding. These should be deleted by the call to removeClusterScopedResourcesIfApplicable")

--- a/controllers/resources_test.go
+++ b/controllers/resources_test.go
@@ -539,6 +539,9 @@ var _ = Describe("Resource creation and cleanup tests", func() {
 		})
 
 		It("Test for Custom Labels for secrets created by Rollouts Manager function", func() {
+			r = makeTestReconcilerWithCustomLabels(map[string]string{
+				"custom1": "value",
+			}, &a)
 			Expect(r.reconcileRolloutsSecrets(ctx, a)).To(Succeed())
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -66,6 +66,17 @@ func setRolloutsLabelsAndAnnotations(obj *metav1.ObjectMeta) {
 	obj.Labels["app.kubernetes.io/component"] = DefaultArgoRolloutsResourceName
 }
 
+func setCustomLabels(obj *metav1.ObjectMeta, customLabels map[string]string) {
+	if obj.Labels == nil {
+		obj.Labels = map[string]string{}
+	}
+
+	for k, v := range customLabels {
+		obj.Labels[k] = v
+	}
+
+}
+
 // fetchObject will retrieve the object with the given namespace and name using the Kubernetes API.
 // The result will be stored in the given object.
 func fetchObject(ctx context.Context, client client.Client, namespace string, name string, obj client.Object) error {

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -794,6 +794,9 @@ func makeTestReconciler(obj ...client.Object) *RolloutManagerReconciler {
 	return &RolloutManagerReconciler{
 		Client:                       cl,
 		Scheme:                       s,
+		ArgoRolloutsCustomLabel: map[string]string{
+			"custom1": "value",
+		},
 		OpenShiftRoutePluginLocation: "file://non-empty-test-url", // Set a non-real, non-empty value for unit tests: override this to test a specific value
 	}
 }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -792,8 +792,8 @@ func makeTestReconciler(obj ...client.Object) *RolloutManagerReconciler {
 	cl := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(obj...).WithObjects(obj...).Build()
 
 	return &RolloutManagerReconciler{
-		Client:                       cl,
-		Scheme:                       s,
+		Client: cl,
+		Scheme: s,
 		ArgoRolloutsCustomLabel: map[string]string{
 			"custom1": "value",
 		},

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -794,7 +794,7 @@ func makeTestReconciler(obj ...client.Object) *RolloutManagerReconciler {
 	return &RolloutManagerReconciler{
 		Client: cl,
 		Scheme: s,
-		ArgoRolloutsCustomLabel: map[string]string{
+		ResourceLabels: map[string]string{
 			"custom1": "value",
 		},
 		OpenShiftRoutePluginLocation: "file://non-empty-test-url", // Set a non-real, non-empty value for unit tests: override this to test a specific value

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -792,11 +792,30 @@ func makeTestReconciler(obj ...client.Object) *RolloutManagerReconciler {
 	cl := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(obj...).WithObjects(obj...).Build()
 
 	return &RolloutManagerReconciler{
-		Client: cl,
-		Scheme: s,
-		ResourceLabels: map[string]string{
-			"custom1": "value",
-		},
+		Client:                       cl,
+		Scheme:                       s,
+		OpenShiftRoutePluginLocation: "file://non-empty-test-url", // Set a non-real, non-empty value for unit tests: override this to test a specific value
+	}
+}
+
+func makeTestReconcilerWithCustomLabels(resourceLabels map[string]string, obj ...client.Object) *RolloutManagerReconciler {
+	s := scheme.Scheme
+
+	err := rolloutsmanagerv1alpha1.AddToScheme(s)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = monitoringv1.AddToScheme(s)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = crdv1.AddToScheme(s)
+	Expect(err).ToNot(HaveOccurred())
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(obj...).WithObjects(obj...).Build()
+
+	return &RolloutManagerReconciler{
+		Client:                       cl,
+		Scheme:                       s,
+		ResourceLabels:               resourceLabels,
 		OpenShiftRoutePluginLocation: "file://non-empty-test-url", // Set a non-real, non-empty value for unit tests: override this to test a specific value
 	}
 }


### PR DESCRIPTION

**What does this PR do / why we need it**:
- Added the support for custom labels for resources created by ArgoRolloutManager. Currently these labels are only added to ConfigMaps and Secrets that are created by RolloutManager but the labels can be further added to other resources in future. These changes are required as part of memory optimization plans for gitops operator. The added label can help track the configmaps and secrets that are created by the operator. This way the operator can cache only these resources that will help in decreasing the memory consumption of the gitops-operator.

**Which issue(s) this PR fixes**:
Fixes #?
<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
