### PR TITLE
fix: Version override in ArgoCD Rollouts causes operator to use upstream images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.1
 
+# Try to detect Docker or Podman
+CONTAINER_RUNTIME := $(shell command -v docker 2> /dev/null || command -v podman 2> /dev/null)
+
+# If neither Docker nor Podman is found, print an error message and exit
+ifeq ($(CONTAINER_RUNTIME),)
+$(warning "No container runtime (Docker or Podman) found in PATH. Please install one of them.")
+endif
 NAMESPACE_SCOPED_ARGO_ROLLOUTS ?= false
 
 # CHANNELS define the bundle channels used in the bundle.
@@ -165,12 +172,12 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+docker-build: test ## Build container image with the manager.
+	$(CONTAINER_RUNTIME) build -t ${IMG} .
 
 .PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+docker-push: ## Push container image with the manager.
+	$(CONTAINER_RUNTIME) push ${IMG}
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
@@ -273,7 +280,7 @@ bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metada
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_RUNTIME) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
@@ -313,7 +320,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(CONTAINER_RUNTIME) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -2,10 +2,7 @@ package rollouts
 
 import (
 	"context"
-	"crypto"
-	"crypto/sha256"
 	"fmt"
-	"hash"
 	"os"
 	"reflect"
 
@@ -324,10 +321,15 @@ func rolloutsContainer(cr rolloutsmanagerv1alpha1.RolloutManager) (corev1.Contai
 		return corev1.Container{}, err
 	}
 
+	image, err := getRolloutsContainerImage(cr)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
 	return corev1.Container{
 		Args:            commandArgs,
 		Env:             rolloutsEnv,
-		Image:           getRolloutsContainerImage(cr),
+		Image:           image,
 		ImagePullPolicy: corev1.PullAlways,
 		LivenessProbe: &corev1.Probe{
 			FailureThreshold: 3,
@@ -653,52 +655,51 @@ func boolPtr(val bool) *bool {
 }
 
 // Returns the container image for rollouts controller.
-func getRolloutsContainerImage(cr rolloutsmanagerv1alpha1.RolloutManager) string {
-	img, tag := getRolloutsImageAndTag(ArgoRolloutsImageEnvName, cr.Spec.Image, cr.Spec.Version)
-	return resolveRolloutsImageFromEnv(
-		img,
-		tag,
-	)
-}
+func getRolloutsContainerImage(cr rolloutsmanagerv1alpha1.RolloutManager) (string, error) {
 
-func resolveRolloutsImageFromEnv(image, tag string) string {
-	return combineImageTag(image, tag)
-}
+	// Order of priority:
+	// 1) cr.spec.image/tag
+	// 2) env
+	// 3) default images
 
-func getRolloutsImageAndTag(envVar, commonSpecImage, commonSpecVersion string) (string, string) {
-	// Start with defaults
-	image := DefaultArgoRolloutsImage
-	tag := DefaultArgoRolloutsVersion
+	image := cr.Spec.Image
+	tag := cr.Spec.Version
 
 	// Check if environment variable is set
-	envVal := os.Getenv(envVar)
+	envVal := os.Getenv(ArgoRolloutsImageEnvName)
 
-	// If no spec values are provided and env var is set, use env var as-is
-	if envVal != "" && commonSpecImage == "" && commonSpecVersion == "" {
-		return envVal, ""
-	}
-
-	// Parse environment variable image if it exists and we need to extract the base image name
 	if envVal != "" {
-		baseImageName, err := extractBaseImageName(envVal)
-		if err != nil {
-			log.Error(err, "Failed to parse environment variable image", "envVal", envVal)
-			return "", ""
+
+		// If no spec values are provided and env var is set, use env var as-is
+		if image == "" && tag == "" {
+			return envVal, nil
 		}
-		image = baseImageName
+
+		// If no cr.Spec.Image, use value from env
+		if image == "" {
+			// Parse environment variable image if it exists and extract the base image name
+			baseImageName, err := extractBaseImageName(envVal)
+			if err != nil {
+				log.Error(err, "Failed to parse environment variable image", "envVal", envVal)
+				return "", err
+			}
+			image = baseImageName
+		}
+
 	}
 
-	// Apply spec overrides with container spec taking precedence over common spec
-	image = getPriorityValue(commonSpecImage, image)
-	tag = getPriorityValue(commonSpecVersion, tag)
+	if image == "" {
+		image = DefaultArgoRolloutsImage
+	}
+	if tag == "" {
+		tag = DefaultArgoRolloutsVersion
+	}
 
-	return image, tag
+	return combineImageTag(image, tag), nil
 }
 
 // extractBaseImageName extracts the base image name from a full image reference (removing tag/digest)
 func extractBaseImageName(imageRef string) (string, error) {
-	// Handle digest format (image@sha256:...)
-	crypto.RegisterHash(crypto.SHA256, func() hash.Hash { return sha256.New() })
 	ref, err := reference.Parse(imageRef)
 	if err != nil {
 		return "", err
@@ -706,16 +707,10 @@ func extractBaseImageName(imageRef string) (string, error) {
 	var name string
 	if named, ok := ref.(reference.Named); ok {
 		name = named.Name()
+	} else {
+		return "", fmt.Errorf("unable to extract base image name: %s", imageRef)
 	}
 	return name, nil
-}
-
-// getPriorityValue returns the highest priority value from container spec, fallback
-func getPriorityValue(commonLevelSpec, fallback string) string {
-	if commonLevelSpec != "" {
-		return commonLevelSpec
-	}
-	return fallback
 }
 
 // getRolloutsCommand will return the command for the Rollouts controller component.

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	rolloutsmanagerv1alpha1 "github.com/argoproj-labs/argo-rollouts-manager/api/v1alpha1"
+	"github.com/distribution/reference"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -663,25 +664,70 @@ func resolveRolloutsImageFromEnv(image, tag string) string {
 }
 
 func getRolloutsImageAndTag(envVar, commonSpecImage, commonSpecVersion string) (string, string) {
-	img := DefaultArgoRolloutsImage
+	// Start with defaults
+	image := DefaultArgoRolloutsImage
 	tag := DefaultArgoRolloutsVersion
-	if envVal := os.Getenv(envVar); envVal != "" {
-		if envImage, envVersion, found := strings.Cut(envVal, "@"); found {
-			img, tag = envImage, envVersion
-		} else if envImage, envVersion, found := strings.Cut(envVal, ":"); found {
-			img, tag = envImage, envVersion
-		} else {
-			img, tag = envVal, ""
-		}
-	}
-	if commonSpecImage != "" {
-		img = commonSpecImage
+
+	// Check if environment variable is set
+	envVal := os.Getenv(envVar)
+
+	// If no spec values are provided and env var is set, use env var as-is
+	if envVal != "" && commonSpecImage == "" && commonSpecVersion == "" {
+		return envVal, ""
 	}
 
-	if commonSpecVersion != "" {
-		tag = commonSpecVersion
+	// Parse environment variable image if it exists and we need to extract the base image name
+	if envVal != "" {
+		log.Info("Processing environment variable image", "envVal", envVal)
+		baseImageName, err := extractBaseImageName(envVal)
+		if err != nil {
+			log.Error(err, "Failed to parse environment variable image", "envVal", envVal)
+			return "", ""
+		}
+		image = baseImageName
 	}
-	return img, tag
+
+	// Apply spec overrides with container spec taking precedence over common spec
+	image = selectImage(commonSpecImage, image)
+	tag = selectVersion(commonSpecVersion, tag)
+
+	return image, tag
+}
+
+// extractBaseImageName extracts the base image name from a full image reference (removing tag/digest)
+func extractBaseImageName(imageRef string) (string, error) {
+	// Handle digest format (image@sha256:...)
+	if strings.Contains(imageRef, "@") {
+		parts := strings.SplitN(imageRef, "@", 2)
+		named, err := reference.ParseNamed(parts[0])
+		if err != nil {
+			return "", err
+		}
+		return named.Name(), nil
+	}
+
+	// Handle tag format (image:tag) or just image name
+	named, err := reference.ParseNamed(imageRef)
+	if err != nil {
+		return "", err
+	}
+	return named.Name(), nil
+}
+
+// selectImage returns the highest priority image from container spec, common spec, or fallback
+func selectImage(commonSpecImage, fallback string) string {
+	if commonSpecImage != "" {
+		return commonSpecImage
+	}
+	return fallback
+}
+
+// selectVersion returns the highest priority version from container spec, common spec, or fallback
+func selectVersion(commonSpecVersion, fallback string) string {
+	if commonSpecVersion != "" {
+		return commonSpecVersion
+	}
+	return fallback
 }
 
 // getRolloutsCommand will return the command for the Rollouts controller component.

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -2,10 +2,12 @@ package rollouts
 
 import (
 	"context"
+	"crypto"
+	"crypto/sha256"
 	"fmt"
+	"hash"
 	"os"
 	"reflect"
-	"strings"
 
 	rolloutsmanagerv1alpha1 "github.com/argoproj-labs/argo-rollouts-manager/api/v1alpha1"
 	"github.com/distribution/reference"
@@ -696,21 +698,16 @@ func getRolloutsImageAndTag(envVar, commonSpecImage, commonSpecVersion string) (
 // extractBaseImageName extracts the base image name from a full image reference (removing tag/digest)
 func extractBaseImageName(imageRef string) (string, error) {
 	// Handle digest format (image@sha256:...)
-	if strings.Contains(imageRef, "@") {
-		parts := strings.SplitN(imageRef, "@", 2)
-		named, err := reference.ParseNamed(parts[0])
-		if err != nil {
-			return "", err
-		}
-		return named.Name(), nil
-	}
-
-	// Handle tag format (image:tag) or just image name
-	named, err := reference.ParseNamed(imageRef)
+	crypto.RegisterHash(crypto.SHA256, func() hash.Hash { return sha256.New() })
+	ref, err := reference.Parse(imageRef)
 	if err != nil {
 		return "", err
 	}
-	return named.Name(), nil
+	var name string
+	if named, ok := ref.(reference.Named); ok {
+		name = named.Name()
+	}
+	return name, nil
 }
 
 // getPriorityValue returns the highest priority value from container spec, fallback

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -678,7 +678,6 @@ func getRolloutsImageAndTag(envVar, commonSpecImage, commonSpecVersion string) (
 
 	// Parse environment variable image if it exists and we need to extract the base image name
 	if envVal != "" {
-		log.Info("Processing environment variable image", "envVal", envVal)
 		baseImageName, err := extractBaseImageName(envVal)
 		if err != nil {
 			log.Error(err, "Failed to parse environment variable image", "envVal", envVal)
@@ -688,8 +687,8 @@ func getRolloutsImageAndTag(envVar, commonSpecImage, commonSpecVersion string) (
 	}
 
 	// Apply spec overrides with container spec taking precedence over common spec
-	image = selectImage(commonSpecImage, image)
-	tag = selectVersion(commonSpecVersion, tag)
+	image = getPriorityValue(commonSpecImage, image)
+	tag = getPriorityValue(commonSpecVersion, tag)
 
 	return image, tag
 }
@@ -714,18 +713,10 @@ func extractBaseImageName(imageRef string) (string, error) {
 	return named.Name(), nil
 }
 
-// selectImage returns the highest priority image from container spec, common spec, or fallback
-func selectImage(commonSpecImage, fallback string) string {
-	if commonSpecImage != "" {
-		return commonSpecImage
-	}
-	return fallback
-}
-
-// selectVersion returns the highest priority version from container spec, common spec, or fallback
-func selectVersion(commonSpecVersion, fallback string) string {
-	if commonSpecVersion != "" {
-		return commonSpecVersion
+// getPriorityValue returns the highest priority value from container spec, fallback
+func getPriorityValue(commonLevelSpec, fallback string) string {
+	if commonLevelSpec != "" {
+		return commonLevelSpec
 	}
 	return fallback
 }

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	rolloutsmanagerv1alpha1 "github.com/argoproj-labs/argo-rollouts-manager/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -650,26 +651,37 @@ func boolPtr(val bool) *bool {
 
 // Returns the container image for rollouts controller.
 func getRolloutsContainerImage(cr rolloutsmanagerv1alpha1.RolloutManager) string {
-	defaultImg, defaultTag := false, false
+	img, tag := getRolloutsImageAndTag(ArgoRolloutsImageEnvName, cr.Spec.Image, cr.Spec.Version)
+	return resolveRolloutsImageFromEnv(
+		img,
+		tag,
+	)
+}
 
-	img := cr.Spec.Image
-	tag := cr.Spec.Version
+func resolveRolloutsImageFromEnv(image, tag string) string {
+	return combineImageTag(image, tag)
+}
 
-	// If spec is empty, use the defaults
-	if img == "" {
-		img = DefaultArgoRolloutsImage
-		defaultImg = true
+func getRolloutsImageAndTag(envVar, commonSpecImage, commonSpecVersion string) (string, string) {
+	img := DefaultArgoRolloutsImage
+	tag := DefaultArgoRolloutsVersion
+	if envVal := os.Getenv(envVar); envVal != "" {
+		if envImage, envVersion, found := strings.Cut(envVal, "@"); found {
+			img, tag = envImage, envVersion
+		} else if envImage, envVersion, found := strings.Cut(envVal, ":"); found {
+			img, tag = envImage, envVersion
+		} else {
+			img, tag = envVal, ""
+		}
 	}
-	if tag == "" {
-		tag = DefaultArgoRolloutsVersion
-		defaultTag = true
+	if commonSpecImage != "" {
+		img = commonSpecImage
 	}
 
-	// If an env var is specified then use that, but don't override the spec values (if they are present)
-	if e := os.Getenv(ArgoRolloutsImageEnvName); e != "" && (defaultTag && defaultImg) {
-		return e
+	if commonSpecVersion != "" {
+		tag = commonSpecVersion
 	}
-	return combineImageTag(img, tag)
+	return img, tag
 }
 
 // getRolloutsCommand will return the command for the Rollouts controller component.

--- a/controllers/deployment_test.go
+++ b/controllers/deployment_test.go
@@ -727,7 +727,6 @@ var _ = Describe("getRolloutsContainerImage tests", func() {
 	})
 
 	AfterEach(func() {
-		a = *makeTestRolloutManager()
 		os.Unsetenv("ARGO_ROLLOUTS_IMAGE") // Ensure env variable is not set unless needed
 	})
 
@@ -735,21 +734,29 @@ var _ = Describe("getRolloutsContainerImage tests", func() {
 		It("returns the default image and tag combined", func() {
 			a.Spec.Image = ""
 			a.Spec.Version = ""
-			Expect(getRolloutsContainerImage(a)).To(Equal(DefaultArgoRolloutsImage + ":" + DefaultArgoRolloutsVersion))
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(img).To(Equal(DefaultArgoRolloutsImage + ":" + DefaultArgoRolloutsVersion))
 		})
 	})
 
 	When("the spec Image is set but Version is empty", func() {
 		It("returns the custom image with the default tag", func() {
 			a.Spec.Image = "custom-image"
-			Expect(getRolloutsContainerImage(a)).To(Equal("custom-image:" + DefaultArgoRolloutsVersion))
+			a.Spec.Version = ""
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(img).To(Equal("custom-image:" + DefaultArgoRolloutsVersion))
 		})
 	})
 
 	When("the spec Image is empty but Version is set", func() {
 		It("returns the default image with the custom tag", func() {
+			a.Spec.Image = ""
 			a.Spec.Version = "custom-tag"
-			Expect(getRolloutsContainerImage(a)).To(Equal(DefaultArgoRolloutsImage + ":custom-tag"))
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(img).To(Equal(DefaultArgoRolloutsImage + ":custom-tag"))
 		})
 	})
 
@@ -757,14 +764,44 @@ var _ = Describe("getRolloutsContainerImage tests", func() {
 		It("returns the custom image and custom tag combined", func() {
 			a.Spec.Image = "custom-image"
 			a.Spec.Version = "custom-tag"
-			Expect(getRolloutsContainerImage(a)).To(Equal("custom-image:custom-tag"))
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(img).To(Equal("custom-image:custom-tag"))
 		})
 	})
 
 	When("the environment variable is set and spec is empty", func() {
 		It("returns the environment variable image", func() {
-			os.Setenv("ARGO_ROLLOUTS_IMAGE", "env-image")
-			Expect(getRolloutsContainerImage(a)).To(Equal("env-image"))
+			a.Spec.Image = ""
+			a.Spec.Version = ""
+			os.Setenv("ARGO_ROLLOUTS_IMAGE", "quay.io/argoproj/argo-rollouts-custom:latest@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1")
+
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(img).To(Equal("quay.io/argoproj/argo-rollouts-custom:latest@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"))
+		})
+	})
+
+	When("the environment variable is set and version is set, but env contains unparseable image", func() {
+		It("returns an error", func() {
+			a.Spec.Image = ""
+			a.Spec.Version = "custom-tag"
+			os.Setenv("ARGO_ROLLOUTS_IMAGE", "quay.io/argoproj/argo-rollouts-custom:latest@sha256:invalidsha256")
+
+			_, err := getRolloutsContainerImage(a)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("the environment variable is set and image/version are set, but env contains unparseable image", func() {
+		It("does not return an error since env var does not need to be parsed", func() {
+			a.Spec.Image = "custom-image"
+			a.Spec.Version = "custom-tag"
+			os.Setenv("ARGO_ROLLOUTS_IMAGE", "quay.io/argoproj/argo-rollouts-custom:latest@sha256:invalidsha256")
+
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(img).To(Equal("custom-image:custom-tag"))
 		})
 	})
 
@@ -772,10 +809,38 @@ var _ = Describe("getRolloutsContainerImage tests", func() {
 		It("returns the custom image and tag ignoring the environment variable", func() {
 			a.Spec.Image = "custom-image"
 			a.Spec.Version = "custom-tag"
-			os.Setenv("ARGO_ROLLOUTS_IMAGE", "quay.io/argoproj/argo-rollouts:latest")
-			Expect(getRolloutsContainerImage(a)).To(Equal("custom-image:custom-tag"))
+			os.Setenv("ARGO_ROLLOUTS_IMAGE", "quay.io/argoproj/argo-rollouts-custom:latest")
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(img).To(Equal("custom-image:custom-tag"))
 		})
 	})
+
+	When("the environment variable is set, and spec version is set", func() {
+		It("returns the env var image with tag from spec", func() {
+			a.Spec.Image = ""
+			a.Spec.Version = "custom-tag"
+			os.Setenv("ARGO_ROLLOUTS_IMAGE", "quay.io/argoproj/argo-rollouts-custom:latest")
+
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(img).To(Equal("quay.io/argoproj/argo-rollouts-custom:custom-tag"))
+		})
+	})
+
+	When("the environment variable is set with a full sha256 value, and spec version is set", func() {
+		It("returns the env var image with tag from spec", func() {
+			a.Spec.Image = ""
+			a.Spec.Version = "custom-tag"
+			os.Setenv("ARGO_ROLLOUTS_IMAGE", "quay.io/argoproj/argo-rollouts-custom:latest@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1")
+
+			img, err := getRolloutsContainerImage(a)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(img).To(Equal("quay.io/argoproj/argo-rollouts-custom:custom-tag"))
+		})
+	})
+
 })
 
 var _ = Describe("rolloutsContainer tests", func() {

--- a/controllers/deployment_test.go
+++ b/controllers/deployment_test.go
@@ -772,7 +772,7 @@ var _ = Describe("getRolloutsContainerImage tests", func() {
 		It("returns the custom image and tag ignoring the environment variable", func() {
 			a.Spec.Image = "custom-image"
 			a.Spec.Version = "custom-tag"
-			os.Setenv("ARGO_ROLLOUTS_IMAGE", "env-image")
+			os.Setenv("ARGO_ROLLOUTS_IMAGE", "quay.io/argoproj/argo-rollouts:latest")
 			Expect(getRolloutsContainerImage(a)).To(Equal("custom-image:custom-tag"))
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/argoproj-labs/argo-rollouts-manager
 
-go 1.23.0
+go 1.24.5
 
 require (
+	github.com/distribution/reference v0.6.0
 	github.com/go-logr/logr v1.4.1
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
@@ -46,6 +47,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
@@ -79,6 +81,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
**What does this PR do / why we need it**:
- (Provide a list of the changes you have made, and why you made those changes)
- (You don't need to re-mention any changes/reasons which are already documented in the issue)

-made changes for makefile to pick docker or podman
-changed go version in dockerfile

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
Fixes #?
https://issues.redhat.com/browse/GITOPS-7969

<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
