### PR TITLE
chore: upgrade to Argo Rollouts v1.8.4

### DIFF
--- a/controllers/default.go
+++ b/controllers/default.go
@@ -12,7 +12,7 @@ const (
 	DefaultArgoRolloutsImage = "quay.io/argoproj/argo-rollouts"
 
 	// ArgoRolloutsDefaultVersion is the default version for the Rollouts controller.
-	DefaultArgoRolloutsVersion = "v1.8.3" // v1.8.3
+	DefaultArgoRolloutsVersion = "v1.8.4" // v1.8.4
 
 	// DefaultArgoRolloutsResourceName is the default name for Rollouts controller resources such as
 	// deployment, service, role, rolebinding and serviceaccount.

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CURRENT_ROLLOUTS_VERSION=v1.8.3
+CURRENT_ROLLOUTS_VERSION=v1.8.4
 
 function cleanup {
   echo "* Cleaning up"


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Upgrade to newly released Argo Rollouts v1.8.4

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

