### PR TITLE
fix: use metricProviderPlugins for metrics key in configmap

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -21,7 +21,12 @@ import (
 
 // From https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/plugins/
 const TrafficRouterPluginConfigMapKey = "trafficRouterPlugins"
-const MetricPluginConfigMapKey = "metricPlugins"
+
+// MetricPluginConfigMapKey_PreviousInvalidKey is the previous key that was used by the operator, but this key value is incorrect. See 'MetricPluginConfigMapKey' for correct value.
+const MetricPluginConfigMapKey_PreviousInvalidKey = "metricPlugins"
+
+// From https://argo-rollouts.readthedocs.io/en/stable/analysis/plugins/
+const MetricPluginConfigMapKey = "metricProviderPlugins"
 
 // Reconcile the Rollouts Default Config Map.
 func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr rolloutsmanagerv1alpha1.RolloutManager) error {
@@ -143,6 +148,12 @@ func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr ro
 
 	// Check if an update is needed by comparing desired and actual plugin configurations
 	updateNeeded := !reflect.DeepEqual(actualTrafficRouterPlugins, trafficRouterPlugins) || !reflect.DeepEqual(actualMetricPlugins, metricPlugins)
+
+	// Remove the previous invalid metric plugin key if it exists, as it was replaced by MetricPluginConfigMapKey
+	if _, hasOldKey := actualConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]; hasOldKey {
+		delete(actualConfigMap.Data, MetricPluginConfigMapKey_PreviousInvalidKey)
+		updateNeeded = true
+	}
 
 	if updateNeeded {
 		// Update the ConfigMap's plugin data with the new values

--- a/controllers/configmap_test.go
+++ b/controllers/configmap_test.go
@@ -145,6 +145,9 @@ var _ = Describe("ConfigMap Test", func() {
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.Metric[0].Name))
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.Metric[0].Location))
 
+		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(a.Spec.Plugins.Metric[0].Name))
+		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(a.Spec.Plugins.Metric[0].Location))
+
 		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.TrafficManagement[0].Name))
 		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.TrafficManagement[0].Location))
 
@@ -174,6 +177,8 @@ var _ = Describe("ConfigMap Test", func() {
 		By("Verify that ConfigMap is updated with the plugins modified by RolloutManger CR")
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.Metric[0].Name))
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(updatedPluginLocation))
+		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(a.Spec.Plugins.Metric[0].Name))
+		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(updatedPluginLocation))
 
 		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.TrafficManagement[0].Name))
 		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(updatedPluginLocation))
@@ -215,6 +220,51 @@ var _ = Describe("ConfigMap Test", func() {
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).NotTo(ContainSubstring("custom-metric-plugin"))
 
 		By("Verify that the pod has been deleted after the above update.")
+		rolloutsPodList := &corev1.PodList{}
+		err := r.Client.List(ctx, rolloutsPodList, client.InNamespace(a.Namespace), client.MatchingLabels(existingDeployment.Spec.Selector.MatchLabels))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(rolloutsPodList.Items)).To(BeNumerically("==", 0))
+	})
+
+	It("creates a ConfigMap that uses the old key invalid configmap key 'metricPlugins' for configuring metric plugin, and then calls reconcileConfigMap. The old key should be removed and replaced with the new key", func() {
+		By("Adding a pod that matches the deployment's selector, this lets us verify the deployment has been restarted to pick up the change to the ConfigMap")
+		addTestPodToFakeClient(r, a.Namespace, existingDeployment)
+
+		By("Calling reconcileConfigMap to create the initial ConfigMap")
+		Expect(r.reconcileConfigMap(ctx, a)).To(Succeed())
+
+		By("Fetching the created ConfigMap and add metric plugin data under the old invalid key")
+		fetchedConfigMap := &corev1.ConfigMap{}
+		Expect(fetchObject(ctx, r.Client, a.Namespace, DefaultRolloutsConfigMapName, fetchedConfigMap)).To(Succeed())
+		fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey] = "- name: custom-metric-plugin\n  location: " + metricPluginLocation + "\n  sha256: \"\"\n"
+		Expect(r.Client.Update(ctx, fetchedConfigMap)).To(Succeed())
+
+		By("Adding metric plugin through the CR")
+		a.Spec.Plugins.Metric = []v1alpha1.Plugin{
+			{Name: "custom-metric-plugin", Location: metricPluginLocation},
+		}
+		Expect(r.Client.Update(ctx, &a)).To(Succeed())
+
+		By("Calling reconcileConfigMap again")
+		Expect(r.reconcileConfigMap(ctx, a)).To(Succeed())
+
+		By("Fetching the ConfigMap after reconciliation")
+		updatedConfigMap := &corev1.ConfigMap{}
+		Expect(fetchObject(ctx, r.Client, a.Namespace, DefaultRolloutsConfigMapName, updatedConfigMap)).To(Succeed())
+
+		By("Verifying that the new key contains the metric plugin data")
+		Expect(updatedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring("custom-metric-plugin"))
+		Expect(updatedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(metricPluginLocation))
+
+		By("Verifying that the old invalid key has been removed")
+		_, oldKeyExists := updatedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]
+		Expect(oldKeyExists).To(BeFalse())
+
+		By("Verifying that the traffic router plugin is still present")
+		Expect(updatedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(OpenShiftRolloutPluginName))
+		Expect(updatedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(r.OpenShiftRoutePluginLocation))
+
+		By("Verifying that the pod has been deleted after the ConfigMap update")
 		rolloutsPodList := &corev1.PodList{}
 		err := r.Client.List(ctx, rolloutsPodList, client.InNamespace(a.Namespace), client.MatchingLabels(existingDeployment.Spec.Selector.MatchLabels))
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -638,6 +638,8 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 			Expect(configMap.Data[controllers.TrafficRouterPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.TrafficManagement[0].Location))
 			Expect(configMap.Data[controllers.MetricPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].Name))
 			Expect(configMap.Data[controllers.MetricPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].Location))
+			Expect(configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].Name))
+			Expect(configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].Location))
 
 			By("Update traffic and metric plugins")
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&rolloutsManager), &rolloutsManager)).To(Succeed())
@@ -661,7 +663,9 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 				return strings.Contains(configMap.Data[controllers.TrafficRouterPluginConfigMapKey], rolloutsManager.Spec.Plugins.TrafficManagement[0].Name) &&
 					strings.Contains(configMap.Data[controllers.TrafficRouterPluginConfigMapKey], rolloutsManager.Spec.Plugins.TrafficManagement[0].Location) &&
 					strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Name) &&
-					strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Location)
+					strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Location) &&
+					!strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey], rolloutsManager.Spec.Plugins.Metric[0].Name)
+
 			}, "1m", "1s").Should(BeTrue())
 
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&rolloutsManager), &rolloutsManager)).To(Succeed())
@@ -704,6 +708,64 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 			}, "60s", "1s").Should(BeTrue())
 
 			Expect(newPods.Items[0].Name).NotTo(Equal(oldPods.Items[0].Name)) // Ensure the Pod names are different
+		})
+
+		When("the argo-rollouts-config contains the old, incorrect metric plugin key in the ConfiMap", func() {
+			It("should remove the key when the RolloutManager CR is reconciled", func() {
+				rolloutsManager := rolloutsmanagerv1alpha1.RolloutManager{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-rollouts-manager-old-key",
+						Namespace: fixture.TestE2ENamespace,
+					},
+					Spec: rolloutsmanagerv1alpha1.RolloutManagerSpec{
+						NamespaceScoped: namespaceScopedParam,
+						Plugins: rolloutsmanagerv1alpha1.Plugins{
+							Metric: []rolloutsmanagerv1alpha1.Plugin{
+								{
+									Name:     "prometheus",
+									Location: "https://github.com/argoproj-labs/sample-rollouts-metric-plugin/releases/download/v0.0.3/metric-plugin-linux-amd64",
+									SHA256:   "08f588b1c799a37bbe8d0fc74cc1b1492dd70b2c",
+								},
+							},
+						},
+					},
+				}
+
+				Expect(k8sClient.Create(ctx, &rolloutsManager)).To(Succeed())
+
+				By("Verify that RolloutManager is successfully created")
+				Eventually(rolloutsManager, "4m", "5s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
+
+				configMap := corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: controllers.DefaultRolloutsConfigMapName, Namespace: rolloutsManager.Namespace},
+				}
+
+				By("Verify metric plugin is under the new key and not the old key")
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&configMap), &configMap)).To(Succeed())
+				Expect(configMap.Data[controllers.MetricPluginConfigMapKey]).To(ContainSubstring("prometheus"))
+				Expect(configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]).NotTo(ContainSubstring("prometheus"))
+
+				By("Manually inject data under the old invalid key into the ConfigMap")
+				Expect(k8s.UpdateWithoutConflict(ctx, &configMap, k8sClient, func(obj client.Object) {
+					cm, ok := obj.(*corev1.ConfigMap)
+					Expect(ok).To(BeTrue())
+					cm.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey] = cm.Data[controllers.MetricPluginConfigMapKey]
+				})).To(Succeed())
+
+				// We should not need to manually trigger reconciliation here, as the ConfigMap resource is watcehd
+
+				By("Verify the old invalid key is removed and the new key still has the correct data")
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&configMap), &configMap); err != nil {
+						GinkgoWriter.Println(err)
+						return false
+					}
+					_, oldKeyExists := configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]
+					return !oldKeyExists &&
+						strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], "prometheus") &&
+						strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Location)
+				}, "1m", "1s").Should(BeTrue())
+			})
 		})
 
 		When("a namespace-scoped RolloutManager is installed into a namespace that previously contained a cluster-scoped RolloutManager, or vice versa", func() {

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -615,7 +615,7 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 						},
 						Metric: []rolloutsmanagerv1alpha1.Plugin{
 							{
-								Name:     "prometheus",
+								Name:     "argoproj-labs/prometheus",
 								Location: "https://github.com/argoproj-labs/sample-rollouts-metric-plugin/releases/download/v0.0.3/metric-plugin-linux-amd64",
 								SHA256:   "4acc0e7a2c99bd8fe2d9b8ee6da08d531ee3a4373c55c77e3b5ee55c866fae69",
 							}},
@@ -722,7 +722,7 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 						Plugins: rolloutsmanagerv1alpha1.Plugins{
 							Metric: []rolloutsmanagerv1alpha1.Plugin{
 								{
-									Name:     "prometheus",
+									Name:     "argoproj-labs/prometheus",
 									Location: "https://github.com/argoproj-labs/sample-rollouts-metric-plugin/releases/download/v0.0.3/metric-plugin-linux-amd64",
 									SHA256:   "4acc0e7a2c99bd8fe2d9b8ee6da08d531ee3a4373c55c77e3b5ee55c866fae69",
 								},
@@ -752,7 +752,15 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 					cm.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey] = cm.Data[controllers.MetricPluginConfigMapKey]
 				})).To(Succeed())
 
-				// We should not need to manually trigger reconciliation here, as the ConfigMap resource is watcehd
+				By("Trigger re-reconcile of RolloutManager by updating an annotation")
+				Expect(k8s.UpdateWithoutConflict(ctx, &rolloutsManager, k8sClient, func(obj client.Object) {
+					annots := obj.GetAnnotations()
+					if annots == nil {
+						annots = map[string]string{}
+					}
+					annots["trigger-reconcile"] = "true"
+					obj.SetAnnotations(annots)
+				})).To(Succeed())
 
 				By("Verify the old invalid key is removed and the new key still has the correct data")
 				Eventually(func() bool {
@@ -760,10 +768,17 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 						GinkgoWriter.Println(err)
 						return false
 					}
+
 					_, oldKeyExists := configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]
-					return !oldKeyExists &&
+					res := !oldKeyExists &&
 						strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], "prometheus") &&
 						strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Location)
+
+					if !res {
+						GinkgoWriter.Println("configMap:", configMap.Data)
+					}
+
+					return res
 				}, "1m", "1s").Should(BeTrue())
 			})
 		})

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -617,7 +617,7 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 							{
 								Name:     "prometheus",
 								Location: "https://github.com/argoproj-labs/sample-rollouts-metric-plugin/releases/download/v0.0.3/metric-plugin-linux-amd64",
-								SHA256:   "08f588b1c799a37bbe8d0fc74cc1b1492dd70b2c",
+								SHA256:   "4acc0e7a2c99bd8fe2d9b8ee6da08d531ee3a4373c55c77e3b5ee55c866fae69",
 							}},
 					},
 				},
@@ -724,7 +724,7 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 								{
 									Name:     "prometheus",
 									Location: "https://github.com/argoproj-labs/sample-rollouts-metric-plugin/releases/download/v0.0.3/metric-plugin-linux-amd64",
-									SHA256:   "08f588b1c799a37bbe8d0fc74cc1b1492dd70b2c",
+									SHA256:   "4acc0e7a2c99bd8fe2d9b8ee6da08d531ee3a4373c55c77e3b5ee55c866fae69",
 								},
 							},
 						},


### PR DESCRIPTION
**What does this PR do / why we need it**:
- This PR fixes an issue where plugins specified in `spec.plugins.metric` field are not correctly translated into expected `ConfigMap` field
- The value previously used was `metricPlugins`, but it should be `metricProviderPlugins`. See https://argo-rollouts.readthedocs.io/en/stable/analysis/plugins/
- This PR also includes unit/E2E test to verify the issue is resolved

Red Hat public tracker ID: https://issues.redhat.com/browse/GITOPS-9105