### PR TITLE
Migration of kube-rbac-proxy in argo-rollouts-manager

### DIFF
--- a/bundle/manifests/argo-rollouts-manager-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/argo-rollouts-manager-controller-manager-metrics-service_v1_service.yaml
@@ -12,10 +12,10 @@ metadata:
   name: argo-rollouts-manager-controller-manager-metrics-service
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager
 status:

--- a/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-04-09T09:01:41Z"
+    createdAt: "2026-04-15T09:18:19Z"
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: argo-rollouts-manager.v0.0.1
@@ -379,7 +379,7 @@ spec:
               containers:
               - args:
                 - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=:8443
                 - --leader-elect
                 command:
                 - /manager
@@ -391,6 +391,13 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8081
+                  name: health
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -28,5 +28,12 @@ spec:
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--metrics-bind-address=:8443"
         - "--leader-elect"
+        ports:
+        - name: metrics
+          containerPort: 8443
+          protocol: TCP
+        - name: health
+          containerPort: 8081
+          protocol: TCP

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
+      port: metrics
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:

--- a/config/rbac/metrics_service.yaml
+++ b/config/rbac/metrics_service.yaml
@@ -12,9 +12,9 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
**What does this PR do / why we need it**:
- (Provide a list of the changes you have made, and why you made those changes)
- (You don't need to re-mention any changes/reasons which are already documented in the issue)
(Provide a list of the changes you have made, and why you made those changes)
(You don't need to re-mention any changes/reasons which are already documented in the issue)
Since kube-rbac-proxy has been officially deprecated and removed from the GCR repository, we are eliminating this image dependency by transitioning to the controller-runtime’s built-in functionality.
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**Which issue(s) this PR fixes**:
Fixes #?
https://redhat.atlassian.net/browse/GITOPS-9257
<!-- This must link to a GitHub issue. If one does not exist, create one. -->

**How to test changes / Special notes to the reviewer**:
Install argocd rollouts operator with this changes and verify argocd rollouts operator now has only one container created, but metrics should be there as it is without impacting argocd rollouts operator metrics functionality.