### PR TITLE
chore: upgrade to Argo Rollouts v1.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,10 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	## Use release-0.22 as the last version that supports Go 1.24 - https://github.com/kubernetes-sigs/controller-runtime/issues/3358
+	## Feel free to update this when we move to Go 1.25+
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+
 
 .PHONY: operator-sdk
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk

--- a/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/argo-rollouts-manager.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-04-15T09:18:19Z"
+    createdAt: "2026-04-29T08:25:26Z"
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: argo-rollouts-manager.v0.0.1
@@ -218,6 +218,7 @@ spec:
           - get
           - update
         - apiGroups:
+          - eks.amazonaws.com
           - elbv2.k8s.aws
           resources:
           - targetgroupbindings

--- a/bundle/manifests/argoproj.io_analysisruns.yaml
+++ b/bundle/manifests/argoproj.io_analysisruns.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: analysisruns.argoproj.io
 spec:
@@ -263,6 +263,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -330,17 +332,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -381,11 +401,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -397,11 +419,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -412,6 +436,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -428,11 +453,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -444,14 +471,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -477,11 +507,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -511,11 +543,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -526,6 +560,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -539,6 +574,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -555,11 +591,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -589,11 +627,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -604,12 +644,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -631,11 +673,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -665,11 +709,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -680,6 +726,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -693,6 +740,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -709,11 +757,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -743,11 +793,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -758,12 +810,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -775,10 +829,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -793,6 +849,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -808,6 +865,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -831,6 +905,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -843,12 +918,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -859,6 +938,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -866,6 +946,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -880,6 +961,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -897,6 +979,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -938,6 +1021,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -955,6 +1039,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -988,6 +1073,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -997,6 +1084,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1007,6 +1095,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1027,6 +1116,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1101,6 +1191,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1111,6 +1202,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1131,6 +1223,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1191,6 +1284,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1205,20 +1300,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1274,6 +1403,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1284,6 +1414,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1304,6 +1435,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1366,6 +1498,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1377,6 +1512,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1386,18 +1523,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1407,10 +1551,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1423,10 +1569,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1441,6 +1589,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1456,6 +1605,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1479,6 +1645,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1491,12 +1658,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1507,6 +1678,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1514,6 +1686,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1528,6 +1701,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1545,6 +1719,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1586,6 +1761,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1603,6 +1779,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1636,6 +1813,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1645,6 +1824,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1655,6 +1835,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1675,6 +1856,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1749,6 +1931,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1759,6 +1942,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1779,6 +1963,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1839,6 +2024,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1853,20 +2040,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1922,6 +2143,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1932,6 +2154,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1952,6 +2175,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2016,6 +2240,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2027,6 +2254,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2036,12 +2265,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2049,10 +2284,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2063,14 +2304,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2078,10 +2325,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2096,6 +2345,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2111,6 +2361,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2134,6 +2401,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2146,12 +2414,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2162,6 +2434,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2169,6 +2442,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2183,6 +2457,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2200,6 +2475,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2241,6 +2517,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2258,6 +2535,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2291,6 +2569,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2300,6 +2580,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2310,6 +2591,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2330,6 +2612,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2404,6 +2687,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2414,6 +2698,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2434,6 +2719,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2494,6 +2780,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2508,20 +2796,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2577,6 +2899,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2587,6 +2910,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2607,6 +2931,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2669,6 +2994,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2680,6 +3008,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2689,12 +3019,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2733,18 +3069,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2752,6 +3086,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2772,6 +3139,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2785,6 +3161,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2810,6 +3188,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2822,6 +3203,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2863,6 +3245,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2879,11 +3262,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2944,6 +3329,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2963,10 +3350,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2983,10 +3368,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/bundle/manifests/argoproj.io_analysistemplates.yaml
+++ b/bundle/manifests/argoproj.io_analysistemplates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: analysistemplates.argoproj.io
 spec:
@@ -259,6 +259,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -326,17 +328,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -377,11 +397,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -393,11 +415,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -408,6 +432,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -424,11 +449,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -440,14 +467,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -473,11 +503,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -507,11 +539,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -522,6 +556,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -535,6 +570,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -551,11 +587,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -585,11 +623,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -600,12 +640,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -627,11 +669,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -661,11 +705,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -676,6 +722,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -689,6 +736,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -705,11 +753,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -739,11 +789,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -754,12 +806,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -771,10 +825,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -789,6 +845,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -804,6 +861,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -827,6 +901,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -839,12 +914,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -855,6 +934,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -862,6 +942,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -876,6 +957,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -893,6 +975,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -934,6 +1017,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -951,6 +1035,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -984,6 +1069,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -993,6 +1080,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1003,6 +1091,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1023,6 +1112,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1097,6 +1187,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1107,6 +1198,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1127,6 +1219,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1187,6 +1280,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1201,20 +1296,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1270,6 +1399,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1280,6 +1410,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1300,6 +1431,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1362,6 +1494,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1373,6 +1508,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1382,18 +1519,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1403,10 +1547,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1419,10 +1565,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1437,6 +1585,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1452,6 +1601,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1475,6 +1641,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1487,12 +1654,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1503,6 +1674,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1510,6 +1682,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1524,6 +1697,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1541,6 +1715,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1582,6 +1757,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1599,6 +1775,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1632,6 +1809,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1641,6 +1820,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1651,6 +1831,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1671,6 +1852,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1745,6 +1927,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1755,6 +1938,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1775,6 +1959,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1835,6 +2020,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1849,20 +2036,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1918,6 +2139,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1928,6 +2150,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1948,6 +2171,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2012,6 +2236,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2023,6 +2250,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2032,12 +2261,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2045,10 +2280,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2059,14 +2300,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2074,10 +2321,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2092,6 +2341,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2107,6 +2357,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2130,6 +2397,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2142,12 +2410,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2158,6 +2430,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2165,6 +2438,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2179,6 +2453,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2196,6 +2471,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2237,6 +2513,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2254,6 +2531,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2287,6 +2565,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2296,6 +2576,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2306,6 +2587,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2326,6 +2608,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2400,6 +2683,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2410,6 +2694,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2430,6 +2715,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2490,6 +2776,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2504,20 +2792,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2573,6 +2895,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2583,6 +2906,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2603,6 +2927,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2665,6 +2990,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2676,6 +3004,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2685,12 +3015,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2729,18 +3065,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2748,6 +3082,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2768,6 +3135,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2781,6 +3157,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2806,6 +3184,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2818,6 +3199,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2859,6 +3241,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2875,11 +3258,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2940,6 +3325,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2959,10 +3346,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2979,10 +3364,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/bundle/manifests/argoproj.io_clusteranalysistemplates.yaml
+++ b/bundle/manifests/argoproj.io_clusteranalysistemplates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: clusteranalysistemplates.argoproj.io
 spec:
@@ -259,6 +259,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -326,17 +328,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -377,11 +397,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -393,11 +415,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -408,6 +432,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -424,11 +449,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -440,14 +467,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -473,11 +503,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -507,11 +539,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -522,6 +556,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -535,6 +570,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -551,11 +587,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -585,11 +623,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -600,12 +640,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -627,11 +669,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -661,11 +705,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -676,6 +722,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -689,6 +736,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -705,11 +753,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -739,11 +789,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -754,12 +806,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -771,10 +825,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -789,6 +845,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -804,6 +861,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -827,6 +901,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -839,12 +914,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -855,6 +934,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -862,6 +942,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -876,6 +957,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -893,6 +975,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -934,6 +1017,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -951,6 +1035,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -984,6 +1069,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -993,6 +1080,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1003,6 +1091,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1023,6 +1112,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1097,6 +1187,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1107,6 +1198,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1127,6 +1219,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1187,6 +1280,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1201,20 +1296,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1270,6 +1399,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1280,6 +1410,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1300,6 +1431,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1362,6 +1494,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1373,6 +1508,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1382,18 +1519,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1403,10 +1547,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1419,10 +1565,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1437,6 +1585,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1452,6 +1601,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1475,6 +1641,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1487,12 +1654,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1503,6 +1674,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1510,6 +1682,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1524,6 +1697,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1541,6 +1715,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1582,6 +1757,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1599,6 +1775,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1632,6 +1809,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1641,6 +1820,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1651,6 +1831,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1671,6 +1852,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1745,6 +1927,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1755,6 +1938,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1775,6 +1959,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1835,6 +2020,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1849,20 +2036,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1918,6 +2139,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1928,6 +2150,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1948,6 +2171,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2012,6 +2236,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2023,6 +2250,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2032,12 +2261,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2045,10 +2280,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2059,14 +2300,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2074,10 +2321,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2092,6 +2341,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2107,6 +2357,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2130,6 +2397,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2142,12 +2410,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2158,6 +2430,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2165,6 +2438,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2179,6 +2453,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2196,6 +2471,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2237,6 +2513,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2254,6 +2531,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2287,6 +2565,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2296,6 +2576,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2306,6 +2587,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2326,6 +2608,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2400,6 +2683,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2410,6 +2694,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2430,6 +2715,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2490,6 +2776,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2504,20 +2792,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2573,6 +2895,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2583,6 +2906,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2603,6 +2927,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2665,6 +2990,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2676,6 +3004,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2685,12 +3015,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2729,18 +3065,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2748,6 +3082,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2768,6 +3135,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2781,6 +3157,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2806,6 +3184,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2818,6 +3199,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2859,6 +3241,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2875,11 +3258,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2940,6 +3325,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2959,10 +3346,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2979,10 +3364,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/bundle/manifests/argoproj.io_experiments.yaml
+++ b/bundle/manifests/argoproj.io_experiments.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: experiments.argoproj.io
 spec:
@@ -149,11 +149,13 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - key
                             - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
@@ -203,11 +205,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchFields:
                                                 items:
                                                   properties:
@@ -219,11 +223,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           weight:
@@ -234,6 +240,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       properties:
                                         nodeSelectorTerms:
@@ -250,11 +257,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchFields:
                                                 items:
                                                   properties:
@@ -266,14 +275,17 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                       - nodeSelectorTerms
                                       type: object
@@ -299,11 +311,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -333,11 +347,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -348,6 +364,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               topologyKey:
                                                 type: string
                                             required:
@@ -361,6 +378,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       items:
                                         properties:
@@ -377,11 +395,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -411,11 +431,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -426,12 +448,14 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
                                             type: string
                                         required:
                                         - topologyKey
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 podAntiAffinity:
                                   properties:
@@ -453,11 +477,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -487,11 +513,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -502,6 +530,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               topologyKey:
                                                 type: string
                                             required:
@@ -515,6 +544,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       items:
                                         properties:
@@ -531,11 +561,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -565,11 +597,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -580,12 +614,14 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
                                             type: string
                                         required:
                                         - topologyKey
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                               type: object
                             automountServiceAccountToken:
@@ -597,10 +633,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -615,6 +653,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -630,6 +669,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -653,6 +709,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -665,12 +722,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -681,6 +742,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -688,6 +750,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -702,6 +765,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -719,6 +783,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -760,6 +825,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -777,6 +843,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -810,6 +877,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -819,6 +888,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -829,6 +899,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -849,6 +920,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -923,6 +995,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -933,6 +1006,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -953,6 +1027,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1013,6 +1088,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -1027,20 +1104,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -1096,6 +1207,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1106,6 +1218,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1126,6 +1239,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1188,6 +1302,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -1199,6 +1316,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -1208,18 +1327,25 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             dnsConfig:
                               properties:
                                 nameservers:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 options:
                                   items:
                                     properties:
@@ -1229,10 +1355,12 @@ spec:
                                         type: string
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 searches:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             dnsPolicy:
                               type: string
@@ -1245,10 +1373,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -1263,6 +1393,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1278,6 +1409,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -1301,6 +1449,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1313,12 +1462,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1329,6 +1482,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1336,6 +1490,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -1350,6 +1505,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -1367,6 +1523,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -1408,6 +1565,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -1425,6 +1583,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -1458,6 +1617,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -1467,6 +1628,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1477,6 +1639,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1497,6 +1660,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1571,6 +1735,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1581,6 +1746,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1601,6 +1767,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1661,6 +1828,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -1675,20 +1844,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -1744,6 +1947,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1754,6 +1958,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1774,6 +1979,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1838,6 +2044,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -1849,6 +2058,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -1858,12 +2069,18 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             hostAliases:
                               items:
                                 properties:
@@ -1871,10 +2088,16 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   ip:
                                     type: string
+                                required:
+                                - ip
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - ip
+                              x-kubernetes-list-type: map
                             hostIPC:
                               type: boolean
                             hostNetwork:
@@ -1885,14 +2108,20 @@ spec:
                               type: boolean
                             hostname:
                               type: string
+                            hostnameOverride:
+                              type: string
                             imagePullSecrets:
                               items:
                                 properties:
                                   name:
+                                    default: ""
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             initContainers:
                               items:
                                 properties:
@@ -1900,10 +2129,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -1918,6 +2149,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1933,6 +2165,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -1956,6 +2205,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1968,12 +2218,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1984,6 +2238,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1991,6 +2246,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -2005,6 +2261,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -2022,6 +2279,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -2063,6 +2321,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -2080,6 +2339,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -2113,6 +2373,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -2122,6 +2384,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2132,6 +2395,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2152,6 +2416,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2226,6 +2491,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2236,6 +2502,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2256,6 +2523,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2316,6 +2584,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -2330,20 +2600,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -2399,6 +2703,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2409,6 +2714,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2429,6 +2735,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2491,6 +2798,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -2502,6 +2812,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -2511,12 +2823,18 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             nodeName:
                               type: string
                             nodeSelector:
@@ -2555,18 +2873,16 @@ spec:
                                 - conditionType
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             resourceClaims:
                               items:
                                 properties:
                                   name:
                                     type: string
-                                  source:
-                                    properties:
-                                      resourceClaimName:
-                                        type: string
-                                      resourceClaimTemplateName:
-                                        type: string
-                                    type: object
+                                  resourceClaimName:
+                                    type: string
+                                  resourceClaimTemplateName:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2574,6 +2890,39 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
                             restartPolicy:
                               type: string
                             runtimeClassName:
@@ -2594,6 +2943,15 @@ spec:
                               x-kubernetes-list-type: map
                             securityContext:
                               properties:
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 fsGroup:
                                   format: int64
                                   type: integer
@@ -2607,6 +2965,8 @@ spec:
                                 runAsUser:
                                   format: int64
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   properties:
                                     level:
@@ -2632,6 +2992,9 @@ spec:
                                     format: int64
                                     type: integer
                                   type: array
+                                  x-kubernetes-list-type: atomic
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   items:
                                     properties:
@@ -2644,6 +3007,7 @@ spec:
                                     - value
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 windowsOptions:
                                   properties:
                                     gmsaCredentialSpec:
@@ -2685,6 +3049,7 @@ spec:
                                     type: string
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             topologySpreadConstraints:
                               items:
                                 properties:
@@ -2701,11 +3066,13 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
                                           - key
                                           - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string

--- a/bundle/manifests/argoproj.io_rollouts.yaml
+++ b/bundle/manifests/argoproj.io_rollouts.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: rollouts.argoproj.io
 spec:
@@ -98,17 +98,22 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: .spec.selector is immutable
+                  rule: self == oldSelf
               strategy:
                 properties:
                   blueGreen:
@@ -440,6 +445,17 @@ spec:
                         - pingService
                         - pongService
                         type: object
+                      replicaProgressThreshold:
+                        properties:
+                          type:
+                            type: string
+                          value:
+                            format: int32
+                            type: integer
+                        required:
+                        - type
+                        - value
+                        type: object
                       scaleDownDelayRevisionLimit:
                         format: int32
                         type: integer
@@ -593,6 +609,9 @@ spec:
                                   type: array
                                 duration:
                                   type: string
+                                scaleDownDelaySeconds:
+                                  format: int32
+                                  type: integer
                                 templates:
                                   items:
                                     properties:
@@ -625,11 +644,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                               - key
                                               - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchLabels:
                                             additionalProperties:
                                               type: string
@@ -848,6 +869,10 @@ spec:
                             properties:
                               destinationRule:
                                 properties:
+                                  additionalSubsetNames:
+                                    items:
+                                      type: string
+                                    type: array
                                   canarySubsetName:
                                     type: string
                                   name:
@@ -1013,11 +1038,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchFields:
                                           items:
                                             properties:
@@ -1029,11 +1056,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     weight:
@@ -1044,6 +1073,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 properties:
                                   nodeSelectorTerms:
@@ -1060,11 +1090,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchFields:
                                           items:
                                             properties:
@@ -1076,14 +1108,17 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - nodeSelectorTerms
                                 type: object
@@ -1109,11 +1144,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1143,11 +1180,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1158,6 +1197,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologyKey:
                                           type: string
                                       required:
@@ -1171,6 +1211,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
@@ -1187,11 +1228,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1221,11 +1264,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1236,12 +1281,14 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     topologyKey:
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                           podAntiAffinity:
                             properties:
@@ -1263,11 +1310,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1297,11 +1346,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1312,6 +1363,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologyKey:
                                           type: string
                                       required:
@@ -1325,6 +1377,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
@@ -1341,11 +1394,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1375,11 +1430,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1390,12 +1447,14 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     topologyKey:
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                         type: object
                       automountServiceAccountToken:
@@ -1407,10 +1466,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -1425,6 +1486,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -1440,6 +1502,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -1463,6 +1542,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -1475,12 +1555,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -1491,6 +1575,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -1498,6 +1583,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -1512,6 +1598,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -1529,6 +1616,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -1570,6 +1658,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -1587,6 +1676,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -1620,6 +1710,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -1629,6 +1721,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1639,6 +1732,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1659,6 +1753,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -1733,6 +1828,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1743,6 +1839,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1763,6 +1860,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -1823,6 +1921,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -1837,20 +1937,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -1906,6 +2040,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1916,6 +2051,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1936,6 +2072,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -1998,6 +2135,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -2009,6 +2149,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -2018,18 +2160,25 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       dnsConfig:
                         properties:
                           nameservers:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           options:
                             items:
                               properties:
@@ -2039,10 +2188,12 @@ spec:
                                   type: string
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           searches:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         type: object
                       dnsPolicy:
                         type: string
@@ -2055,10 +2206,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -2073,6 +2226,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2088,6 +2242,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -2111,6 +2282,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2123,12 +2295,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2139,6 +2315,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2146,6 +2323,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -2160,6 +2338,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2177,6 +2356,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2218,6 +2398,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2235,6 +2416,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2268,6 +2450,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -2277,6 +2461,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2287,6 +2472,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2307,6 +2493,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2381,6 +2568,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2391,6 +2579,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2411,6 +2600,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2471,6 +2661,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -2485,20 +2677,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -2554,6 +2780,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2564,6 +2791,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2584,6 +2812,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2648,6 +2877,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -2659,6 +2891,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -2668,12 +2902,18 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       hostAliases:
                         items:
                           properties:
@@ -2681,10 +2921,16 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ip:
                               type: string
+                          required:
+                          - ip
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
                       hostIPC:
                         type: boolean
                       hostNetwork:
@@ -2695,14 +2941,20 @@ spec:
                         type: boolean
                       hostname:
                         type: string
+                      hostnameOverride:
+                        type: string
                       imagePullSecrets:
                         items:
                           properties:
                             name:
+                              default: ""
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       initContainers:
                         items:
                           properties:
@@ -2710,10 +2962,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -2728,6 +2982,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2743,6 +2998,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -2766,6 +3038,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2778,12 +3051,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2794,6 +3071,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2801,6 +3079,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -2815,6 +3094,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2832,6 +3112,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2873,6 +3154,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2890,6 +3172,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2923,6 +3206,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -2932,6 +3217,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2942,6 +3228,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2962,6 +3249,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3036,6 +3324,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -3046,6 +3335,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -3066,6 +3356,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3126,6 +3417,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -3140,20 +3433,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -3209,6 +3536,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -3219,6 +3547,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -3239,6 +3568,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3301,6 +3631,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -3312,6 +3645,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -3321,12 +3656,18 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       nodeName:
                         type: string
                       nodeSelector:
@@ -3365,18 +3706,16 @@ spec:
                           - conditionType
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       resourceClaims:
                         items:
                           properties:
                             name:
                               type: string
-                            source:
-                              properties:
-                                resourceClaimName:
-                                  type: string
-                                resourceClaimTemplateName:
-                                  type: string
-                              type: object
+                            resourceClaimName:
+                              type: string
+                            resourceClaimTemplateName:
+                              type: string
                           required:
                           - name
                           type: object
@@ -3384,6 +3723,39 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       restartPolicy:
                         type: string
                       runtimeClassName:
@@ -3404,6 +3776,15 @@ spec:
                         x-kubernetes-list-type: map
                       securityContext:
                         properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
                           fsGroup:
                             format: int64
                             type: integer
@@ -3417,6 +3798,8 @@ spec:
                           runAsUser:
                             format: int64
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             properties:
                               level:
@@ -3442,6 +3825,9 @@ spec:
                               format: int64
                               type: integer
                             type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             items:
                               properties:
@@ -3454,6 +3840,7 @@ spec:
                               - value
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           windowsOptions:
                             properties:
                               gmsaCredentialSpec:
@@ -3495,6 +3882,7 @@ spec:
                               type: string
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       topologySpreadConstraints:
                         items:
                           properties:
@@ -3511,11 +3899,13 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - key
                                     - operator
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 matchLabels:
                                   additionalProperties:
                                     type: string
@@ -3552,9 +3942,7 @@ spec:
                         - whenUnsatisfiable
                         x-kubernetes-list-type: map
                       volumes:
-                        items:
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
+                        x-kubernetes-preserve-unknown-fields: true
                     required:
                     - containers
                     type: object

--- a/config/crd/bases/analysis-run-crd.yaml
+++ b/config/crd/bases/analysis-run-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: analysisruns.argoproj.io
 spec:
   group: argoproj.io
@@ -13,7 +13,6 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -263,6 +262,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -330,17 +331,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -381,11 +400,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -397,11 +418,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -412,6 +435,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -428,11 +452,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -444,14 +470,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -477,11 +506,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -511,11 +542,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -526,6 +559,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -539,6 +573,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -555,11 +590,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -589,11 +626,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -604,12 +643,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -631,11 +672,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -665,11 +708,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -680,6 +725,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -693,6 +739,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -709,11 +756,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -743,11 +792,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -758,12 +809,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -775,10 +828,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -793,6 +848,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -808,6 +864,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -831,6 +904,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -843,12 +917,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -859,6 +937,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -866,6 +945,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -880,6 +960,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -897,6 +978,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -938,6 +1020,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -955,6 +1038,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -988,6 +1072,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -997,6 +1083,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1007,6 +1094,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1027,6 +1115,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1101,6 +1190,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1111,6 +1201,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1131,6 +1222,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1191,6 +1283,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1205,20 +1299,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1274,6 +1402,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1284,6 +1413,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1304,6 +1434,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1366,6 +1497,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1377,6 +1511,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1386,18 +1522,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1407,10 +1550,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1423,10 +1568,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1441,6 +1588,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1456,6 +1604,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1479,6 +1644,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1491,12 +1657,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1507,6 +1677,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1514,6 +1685,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1528,6 +1700,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1545,6 +1718,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1586,6 +1760,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1603,6 +1778,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1636,6 +1812,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1645,6 +1823,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1655,6 +1834,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1675,6 +1855,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1749,6 +1930,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1759,6 +1941,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1779,6 +1962,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1839,6 +2023,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1853,20 +2039,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1922,6 +2142,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1932,6 +2153,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1952,6 +2174,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2016,6 +2239,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2027,6 +2253,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2036,12 +2264,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2049,10 +2283,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2063,14 +2303,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2078,10 +2324,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2096,6 +2344,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2111,6 +2360,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2134,6 +2400,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2146,12 +2413,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2162,6 +2433,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2169,6 +2441,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2183,6 +2456,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2200,6 +2474,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2241,6 +2516,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2258,6 +2534,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2291,6 +2568,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2300,6 +2579,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2310,6 +2590,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2330,6 +2611,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2404,6 +2686,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2414,6 +2697,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2434,6 +2718,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2494,6 +2779,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2508,20 +2795,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2577,6 +2898,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2587,6 +2909,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2607,6 +2930,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2669,6 +2993,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2680,6 +3007,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2689,12 +3018,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2733,18 +3068,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2752,6 +3085,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2772,6 +3138,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2785,6 +3160,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2810,6 +3187,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2822,6 +3202,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2863,6 +3244,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2879,11 +3261,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2944,6 +3328,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2963,10 +3349,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2983,10 +3367,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/config/crd/bases/analysis-template-crd.yaml
+++ b/config/crd/bases/analysis-template-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: analysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -13,7 +13,6 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -259,6 +258,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -326,17 +327,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -377,11 +396,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -393,11 +414,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -408,6 +431,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -424,11 +448,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -440,14 +466,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -473,11 +502,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -507,11 +538,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -522,6 +555,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -535,6 +569,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -551,11 +586,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -585,11 +622,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -600,12 +639,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -627,11 +668,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -661,11 +704,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -676,6 +721,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -689,6 +735,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -705,11 +752,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -739,11 +788,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -754,12 +805,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -771,10 +824,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -789,6 +844,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -804,6 +860,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -827,6 +900,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -839,12 +913,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -855,6 +933,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -862,6 +941,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -876,6 +956,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -893,6 +974,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -934,6 +1016,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -951,6 +1034,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -984,6 +1068,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -993,6 +1079,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1003,6 +1090,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1023,6 +1111,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1097,6 +1186,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1107,6 +1197,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1127,6 +1218,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1187,6 +1279,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1201,20 +1295,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1270,6 +1398,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1280,6 +1409,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1300,6 +1430,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1362,6 +1493,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1373,6 +1507,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1382,18 +1518,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1403,10 +1546,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1419,10 +1564,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1437,6 +1584,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1452,6 +1600,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1475,6 +1640,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1487,12 +1653,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1503,6 +1673,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1510,6 +1681,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1524,6 +1696,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1541,6 +1714,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1582,6 +1756,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1599,6 +1774,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1632,6 +1808,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1641,6 +1819,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1651,6 +1830,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1671,6 +1851,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1745,6 +1926,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1755,6 +1937,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1775,6 +1958,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1835,6 +2019,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1849,20 +2035,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1918,6 +2138,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1928,6 +2149,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1948,6 +2170,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2012,6 +2235,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2023,6 +2249,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2032,12 +2260,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2045,10 +2279,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2059,14 +2299,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2074,10 +2320,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2092,6 +2340,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2107,6 +2356,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2130,6 +2396,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2142,12 +2409,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2158,6 +2429,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2165,6 +2437,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2179,6 +2452,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2196,6 +2470,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2237,6 +2512,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2254,6 +2530,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2287,6 +2564,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2296,6 +2575,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2306,6 +2586,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2326,6 +2607,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2400,6 +2682,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2410,6 +2693,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2430,6 +2714,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2490,6 +2775,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2504,20 +2791,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2573,6 +2894,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2583,6 +2905,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2603,6 +2926,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2665,6 +2989,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2676,6 +3003,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2685,12 +3014,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2729,18 +3064,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2748,6 +3081,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2768,6 +3134,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2781,6 +3156,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2806,6 +3183,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2818,6 +3198,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2859,6 +3240,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2875,11 +3257,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2940,6 +3324,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2959,10 +3345,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2979,10 +3363,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/config/crd/bases/cluster-analysis-template-crd.yaml
+++ b/config/crd/bases/cluster-analysis-template-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: clusteranalysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -13,7 +13,6 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -259,6 +258,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -326,17 +327,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -377,11 +396,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -393,11 +414,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -408,6 +431,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -424,11 +448,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -440,14 +466,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -473,11 +502,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -507,11 +538,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -522,6 +555,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -535,6 +569,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -551,11 +586,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -585,11 +622,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -600,12 +639,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -627,11 +668,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -661,11 +704,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -676,6 +721,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -689,6 +735,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -705,11 +752,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -739,11 +788,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -754,12 +805,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -771,10 +824,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -789,6 +844,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -804,6 +860,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -827,6 +900,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -839,12 +913,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -855,6 +933,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -862,6 +941,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -876,6 +956,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -893,6 +974,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -934,6 +1016,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -951,6 +1034,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -984,6 +1068,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -993,6 +1079,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1003,6 +1090,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1023,6 +1111,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1097,6 +1186,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1107,6 +1197,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1127,6 +1218,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1187,6 +1279,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1201,20 +1295,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1270,6 +1398,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1280,6 +1409,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1300,6 +1430,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1362,6 +1493,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1373,6 +1507,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1382,18 +1518,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1403,10 +1546,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1419,10 +1564,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1437,6 +1584,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1452,6 +1600,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1475,6 +1640,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1487,12 +1653,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1503,6 +1673,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1510,6 +1681,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1524,6 +1696,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1541,6 +1714,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1582,6 +1756,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1599,6 +1774,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1632,6 +1808,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1641,6 +1819,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1651,6 +1830,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1671,6 +1851,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1745,6 +1926,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1755,6 +1937,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1775,6 +1958,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1835,6 +2019,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1849,20 +2035,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1918,6 +2138,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1928,6 +2149,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1948,6 +2170,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2012,6 +2235,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2023,6 +2249,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2032,12 +2260,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2045,10 +2279,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2059,14 +2299,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2074,10 +2320,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2092,6 +2340,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2107,6 +2356,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2130,6 +2396,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2142,12 +2409,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2158,6 +2429,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2165,6 +2437,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2179,6 +2452,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2196,6 +2470,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2237,6 +2512,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2254,6 +2530,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2287,6 +2564,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2296,6 +2575,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2306,6 +2586,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2326,6 +2607,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2400,6 +2682,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2410,6 +2693,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2430,6 +2714,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2490,6 +2775,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2504,20 +2791,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2573,6 +2894,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2583,6 +2905,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2603,6 +2926,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2665,6 +2989,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2676,6 +3003,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2685,12 +3014,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2729,18 +3064,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2748,6 +3081,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2768,6 +3134,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2781,6 +3156,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2806,6 +3183,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2818,6 +3198,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2859,6 +3240,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2875,11 +3257,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2940,6 +3324,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2959,10 +3345,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2979,10 +3363,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/config/crd/bases/experiment-crd.yaml
+++ b/config/crd/bases/experiment-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: experiments.argoproj.io
 spec:
   group: argoproj.io
@@ -13,7 +13,6 @@ spec:
     shortNames:
     - exp
     singular: experiment
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -149,11 +148,13 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - key
                             - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
@@ -203,11 +204,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchFields:
                                                 items:
                                                   properties:
@@ -219,11 +222,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           weight:
@@ -234,6 +239,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       properties:
                                         nodeSelectorTerms:
@@ -250,11 +256,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchFields:
                                                 items:
                                                   properties:
@@ -266,14 +274,17 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                       - nodeSelectorTerms
                                       type: object
@@ -299,11 +310,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -333,11 +346,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -348,6 +363,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               topologyKey:
                                                 type: string
                                             required:
@@ -361,6 +377,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       items:
                                         properties:
@@ -377,11 +394,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -411,11 +430,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -426,12 +447,14 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
                                             type: string
                                         required:
                                         - topologyKey
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 podAntiAffinity:
                                   properties:
@@ -453,11 +476,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -487,11 +512,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -502,6 +529,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               topologyKey:
                                                 type: string
                                             required:
@@ -515,6 +543,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       items:
                                         properties:
@@ -531,11 +560,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -565,11 +596,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -580,12 +613,14 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
                                             type: string
                                         required:
                                         - topologyKey
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                               type: object
                             automountServiceAccountToken:
@@ -597,10 +632,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -615,6 +652,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -630,6 +668,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -653,6 +708,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -665,12 +721,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -681,6 +741,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -688,6 +749,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -702,6 +764,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -719,6 +782,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -760,6 +824,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -777,6 +842,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -810,6 +876,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -819,6 +887,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -829,6 +898,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -849,6 +919,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -923,6 +994,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -933,6 +1005,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -953,6 +1026,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1013,6 +1087,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -1027,20 +1103,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -1096,6 +1206,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1106,6 +1217,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1126,6 +1238,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1188,6 +1301,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -1199,6 +1315,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -1208,18 +1326,25 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             dnsConfig:
                               properties:
                                 nameservers:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 options:
                                   items:
                                     properties:
@@ -1229,10 +1354,12 @@ spec:
                                         type: string
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 searches:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             dnsPolicy:
                               type: string
@@ -1245,10 +1372,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -1263,6 +1392,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1278,6 +1408,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -1301,6 +1448,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1313,12 +1461,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1329,6 +1481,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1336,6 +1489,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -1350,6 +1504,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -1367,6 +1522,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -1408,6 +1564,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -1425,6 +1582,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -1458,6 +1616,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -1467,6 +1627,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1477,6 +1638,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1497,6 +1659,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1571,6 +1734,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1581,6 +1745,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1601,6 +1766,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1661,6 +1827,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -1675,20 +1843,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -1744,6 +1946,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1754,6 +1957,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1774,6 +1978,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1838,6 +2043,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -1849,6 +2057,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -1858,12 +2068,18 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             hostAliases:
                               items:
                                 properties:
@@ -1871,10 +2087,16 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   ip:
                                     type: string
+                                required:
+                                - ip
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - ip
+                              x-kubernetes-list-type: map
                             hostIPC:
                               type: boolean
                             hostNetwork:
@@ -1885,14 +2107,20 @@ spec:
                               type: boolean
                             hostname:
                               type: string
+                            hostnameOverride:
+                              type: string
                             imagePullSecrets:
                               items:
                                 properties:
                                   name:
+                                    default: ""
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             initContainers:
                               items:
                                 properties:
@@ -1900,10 +2128,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -1918,6 +2148,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1933,6 +2164,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -1956,6 +2204,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1968,12 +2217,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1984,6 +2237,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1991,6 +2245,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -2005,6 +2260,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -2022,6 +2278,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -2063,6 +2320,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -2080,6 +2338,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -2113,6 +2372,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -2122,6 +2383,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2132,6 +2394,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2152,6 +2415,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2226,6 +2490,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2236,6 +2501,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2256,6 +2522,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2316,6 +2583,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -2330,20 +2599,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -2399,6 +2702,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2409,6 +2713,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2429,6 +2734,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2491,6 +2797,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -2502,6 +2811,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -2511,12 +2822,18 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             nodeName:
                               type: string
                             nodeSelector:
@@ -2555,18 +2872,16 @@ spec:
                                 - conditionType
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             resourceClaims:
                               items:
                                 properties:
                                   name:
                                     type: string
-                                  source:
-                                    properties:
-                                      resourceClaimName:
-                                        type: string
-                                      resourceClaimTemplateName:
-                                        type: string
-                                    type: object
+                                  resourceClaimName:
+                                    type: string
+                                  resourceClaimTemplateName:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2574,6 +2889,39 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
                             restartPolicy:
                               type: string
                             runtimeClassName:
@@ -2594,6 +2942,15 @@ spec:
                               x-kubernetes-list-type: map
                             securityContext:
                               properties:
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 fsGroup:
                                   format: int64
                                   type: integer
@@ -2607,6 +2964,8 @@ spec:
                                 runAsUser:
                                   format: int64
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   properties:
                                     level:
@@ -2632,6 +2991,9 @@ spec:
                                     format: int64
                                     type: integer
                                   type: array
+                                  x-kubernetes-list-type: atomic
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   items:
                                     properties:
@@ -2644,6 +3006,7 @@ spec:
                                     - value
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 windowsOptions:
                                   properties:
                                     gmsaCredentialSpec:
@@ -2685,6 +3048,7 @@ spec:
                                     type: string
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             topologySpreadConstraints:
                               items:
                                 properties:
@@ -2701,11 +3065,13 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
                                           - key
                                           - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string

--- a/config/crd/bases/rollout-crd.yaml
+++ b/config/crd/bases/rollout-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: rollouts.argoproj.io
 spec:
   group: argoproj.io
@@ -13,7 +13,6 @@ spec:
     shortNames:
     - ro
     singular: rollout
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -98,17 +97,22 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: .spec.selector is immutable
+                  rule: self == oldSelf
               strategy:
                 properties:
                   blueGreen:
@@ -440,6 +444,17 @@ spec:
                         - pingService
                         - pongService
                         type: object
+                      replicaProgressThreshold:
+                        properties:
+                          type:
+                            type: string
+                          value:
+                            format: int32
+                            type: integer
+                        required:
+                        - type
+                        - value
+                        type: object
                       scaleDownDelayRevisionLimit:
                         format: int32
                         type: integer
@@ -593,6 +608,9 @@ spec:
                                   type: array
                                 duration:
                                   type: string
+                                scaleDownDelaySeconds:
+                                  format: int32
+                                  type: integer
                                 templates:
                                   items:
                                     properties:
@@ -625,11 +643,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                               - key
                                               - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchLabels:
                                             additionalProperties:
                                               type: string
@@ -848,6 +868,10 @@ spec:
                             properties:
                               destinationRule:
                                 properties:
+                                  additionalSubsetNames:
+                                    items:
+                                      type: string
+                                    type: array
                                   canarySubsetName:
                                     type: string
                                   name:
@@ -1013,11 +1037,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchFields:
                                           items:
                                             properties:
@@ -1029,11 +1055,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     weight:
@@ -1044,6 +1072,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 properties:
                                   nodeSelectorTerms:
@@ -1060,11 +1089,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchFields:
                                           items:
                                             properties:
@@ -1076,14 +1107,17 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - nodeSelectorTerms
                                 type: object
@@ -1109,11 +1143,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1143,11 +1179,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1158,6 +1196,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologyKey:
                                           type: string
                                       required:
@@ -1171,6 +1210,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
@@ -1187,11 +1227,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1221,11 +1263,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1236,12 +1280,14 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     topologyKey:
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                           podAntiAffinity:
                             properties:
@@ -1263,11 +1309,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1297,11 +1345,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1312,6 +1362,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologyKey:
                                           type: string
                                       required:
@@ -1325,6 +1376,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
@@ -1341,11 +1393,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1375,11 +1429,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1390,12 +1446,14 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     topologyKey:
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                         type: object
                       automountServiceAccountToken:
@@ -1407,10 +1465,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -1425,6 +1485,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -1440,6 +1501,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -1463,6 +1541,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -1475,12 +1554,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -1491,6 +1574,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -1498,6 +1582,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -1512,6 +1597,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -1529,6 +1615,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -1570,6 +1657,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -1587,6 +1675,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -1620,6 +1709,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -1629,6 +1720,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1639,6 +1731,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1659,6 +1752,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -1733,6 +1827,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1743,6 +1838,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1763,6 +1859,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -1823,6 +1920,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -1837,20 +1936,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -1906,6 +2039,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1916,6 +2050,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1936,6 +2071,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -1998,6 +2134,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -2009,6 +2148,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -2018,18 +2159,25 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       dnsConfig:
                         properties:
                           nameservers:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           options:
                             items:
                               properties:
@@ -2039,10 +2187,12 @@ spec:
                                   type: string
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           searches:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         type: object
                       dnsPolicy:
                         type: string
@@ -2055,10 +2205,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -2073,6 +2225,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2088,6 +2241,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -2111,6 +2281,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2123,12 +2294,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2139,6 +2314,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2146,6 +2322,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -2160,6 +2337,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2177,6 +2355,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2218,6 +2397,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2235,6 +2415,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2268,6 +2449,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -2277,6 +2460,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2287,6 +2471,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2307,6 +2492,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2381,6 +2567,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2391,6 +2578,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2411,6 +2599,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2471,6 +2660,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -2485,20 +2676,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -2554,6 +2779,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2564,6 +2790,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2584,6 +2811,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2648,6 +2876,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -2659,6 +2890,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -2668,12 +2901,18 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       hostAliases:
                         items:
                           properties:
@@ -2681,10 +2920,16 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ip:
                               type: string
+                          required:
+                          - ip
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
                       hostIPC:
                         type: boolean
                       hostNetwork:
@@ -2695,14 +2940,20 @@ spec:
                         type: boolean
                       hostname:
                         type: string
+                      hostnameOverride:
+                        type: string
                       imagePullSecrets:
                         items:
                           properties:
                             name:
+                              default: ""
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       initContainers:
                         items:
                           properties:
@@ -2710,10 +2961,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -2728,6 +2981,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2743,6 +2997,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -2766,6 +3037,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2778,12 +3050,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2794,6 +3070,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2801,6 +3078,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -2815,6 +3093,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2832,6 +3111,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2873,6 +3153,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2890,6 +3171,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2923,6 +3205,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -2932,6 +3216,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2942,6 +3227,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2962,6 +3248,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3036,6 +3323,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -3046,6 +3334,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -3066,6 +3355,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3126,6 +3416,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -3140,20 +3432,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -3209,6 +3535,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -3219,6 +3546,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -3239,6 +3567,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3301,6 +3630,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -3312,6 +3644,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -3321,12 +3655,18 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       nodeName:
                         type: string
                       nodeSelector:
@@ -3365,18 +3705,16 @@ spec:
                           - conditionType
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       resourceClaims:
                         items:
                           properties:
                             name:
                               type: string
-                            source:
-                              properties:
-                                resourceClaimName:
-                                  type: string
-                                resourceClaimTemplateName:
-                                  type: string
-                              type: object
+                            resourceClaimName:
+                              type: string
+                            resourceClaimTemplateName:
+                              type: string
                           required:
                           - name
                           type: object
@@ -3384,6 +3722,39 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       restartPolicy:
                         type: string
                       runtimeClassName:
@@ -3404,6 +3775,15 @@ spec:
                         x-kubernetes-list-type: map
                       securityContext:
                         properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
                           fsGroup:
                             format: int64
                             type: integer
@@ -3417,6 +3797,8 @@ spec:
                           runAsUser:
                             format: int64
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             properties:
                               level:
@@ -3442,6 +3824,9 @@ spec:
                               format: int64
                               type: integer
                             type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             items:
                               properties:
@@ -3454,6 +3839,7 @@ spec:
                               - value
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           windowsOptions:
                             properties:
                               gmsaCredentialSpec:
@@ -3495,6 +3881,7 @@ spec:
                               type: string
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       topologySpreadConstraints:
                         items:
                           properties:
@@ -3511,11 +3898,13 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - key
                                     - operator
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 matchLabels:
                                   additionalProperties:
                                     type: string
@@ -3552,9 +3941,7 @@ spec:
                         - whenUnsatisfiable
                         x-kubernetes-list-type: map
                       volumes:
-                        items:
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
+                        x-kubernetes-preserve-unknown-fields: true
                     required:
                     - containers
                     type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -163,6 +163,7 @@ rules:
   - get
   - update
 - apiGroups:
+  - eks.amazonaws.com
   - elbv2.k8s.aws
   resources:
   - targetgroupbindings

--- a/controllers/argorollouts_controller.go
+++ b/controllers/argorollouts_controller.go
@@ -83,6 +83,7 @@ const (
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=create;get;update
 //+kubebuilder:rbac:groups="elbv2.k8s.aws",resources=targetgroupbindings,verbs=list;get
+//+kubebuilder:rbac:groups="eks.amazonaws.com",resources=targetgroupbindings,verbs=list;get
 //+kubebuilder:rbac:groups="extensions",resources=ingresses,verbs=create;get;list;watch;patch
 //+kubebuilder:rbac:groups="getambassador.io",resources=ambassadormappings;mappings,verbs=create;watch;get;update;list;delete
 //+kubebuilder:rbac:groups="networking.istio.io",resources=destinationrules;virtualservices,verbs=watch;get;update;patch;list

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -12,7 +12,7 @@ const (
 	DefaultArgoRolloutsImage = "quay.io/argoproj/argo-rollouts"
 
 	// ArgoRolloutsDefaultVersion is the default version for the Rollouts controller.
-	DefaultArgoRolloutsVersion = "v1.8.4" // v1.8.4
+	DefaultArgoRolloutsVersion = "v1.9.0" // v1.9.0
 
 	// DefaultArgoRolloutsResourceName is the default name for Rollouts controller resources such as
 	// deployment, service, role, rolebinding and serviceaccount.

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -1073,6 +1073,7 @@ func GetPolicyRules() []rbacv1.PolicyRule {
 		{
 			APIGroups: []string{
 				"elbv2.k8s.aws",
+				"eks.amazonaws.com",
 			},
 			Resources: []string{
 				"targetgroupbindings",

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -39,10 +39,10 @@ find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/nginx:1.19
 find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/nginx:1.14.2/quay.io\/jgwest-redhat\/nginx@sha256:07ab71a2c8e4ecb19a5a5abcfb3a4f175946c001c8af288b1aa766d67b0d05d2/g'
 
 # 2c) replace the rollouts-pod-template-hash of 'TestCanaryDynamicStableScale', since we have updated the image above
-find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/868d98995b/5496d694d6/g'
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/6b56c8cdb4/7947d69f98/g'
 
 # replace the TestCanaryScaleDownOnAbort and TestCanaryScaleDownOnAbortNoTrafficRouting, for same reason
-find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/66597877b7/6fcb5674b5/g'
+find "$TMP_DIR/argo-rollouts/test/e2e" -type f | xargs sed -i.bak  's/674d8cf959/7c985c987c/g'
 
 
 find "$TMP_DIR/argo-rollouts/test/e2e" -type f -name "*.bak" -delete

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CURRENT_ROLLOUTS_VERSION=v1.8.4
+CURRENT_ROLLOUTS_VERSION=v1.9.0
 
 function cleanup {
   echo "* Cleaning up"
@@ -144,4 +144,5 @@ set -e
 "$SCRIPT_DIR/verify-rollouts-e2e-tests/verify-e2e-test-results.sh" /tmp/test-e2e.log
 
 echo "* SUCCESS: No unexpected errors occurred."
+
 


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Upgrade to v1.9.0 release of Argo Rollouts
