### PR TITLE
fix: fix sha256 value in configmap for Traffic Management plugin, and update E2E/unit tests

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -68,6 +68,7 @@ func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr ro
 			trafficRouterPluginsMap[plugin.Name] = pluginItem{
 				Name:     plugin.Name,
 				Location: plugin.Location,
+				Sha256:   plugin.SHA256,
 			}
 		}
 	}
@@ -134,7 +135,7 @@ func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr ro
 			log.Info("configMap not found, creating default configmap with openshift route plugin information")
 			return r.Client.Create(ctx, desiredConfigMap)
 		}
-		return fmt.Errorf("failed to get the serviceAccount associated with %s: %w", desiredConfigMap.Name, err)
+		return fmt.Errorf("failed to get the ConfigMap associated with %s: %w", desiredConfigMap.Name, err)
 	}
 
 	// Unmarshal the existing plugin data from the actual ConfigMap
@@ -170,8 +171,10 @@ func (r *RolloutManagerReconciler) reconcileConfigMap(ctx context.Context, cr ro
 		if err := r.restartRolloutsPod(ctx, cr.Namespace); err != nil {
 			return err
 		}
+	} else {
+		log.Info("No changes detected in ConfigMap, skipping update and pod restart")
 	}
-	log.Info("No changes detected in ConfigMap, skipping update and pod restart")
+
 	return nil
 }
 

--- a/controllers/configmap_test.go
+++ b/controllers/configmap_test.go
@@ -121,7 +121,7 @@ var _ = Describe("ConfigMap Test", func() {
 
 		By("Adding traffic and metric plugins through the CR")
 		a.Spec.Plugins.TrafficManagement = []v1alpha1.Plugin{
-			{Name: "custom-traffic-plugin", Location: trafficrouterPluginLocation},
+			{Name: "custom-traffic-plugin", Location: trafficrouterPluginLocation, SHA256: "sha256-traffic-test"},
 		}
 		a.Spec.Plugins.Metric = []v1alpha1.Plugin{
 			{Name: "custom-metric-plugin", Location: metricPluginLocation, SHA256: "sha256-test"},
@@ -144,18 +144,20 @@ var _ = Describe("ConfigMap Test", func() {
 		By("Verify that the fetched ConfigMap contains plugins added by CR")
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.Metric[0].Name))
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.Metric[0].Location))
+		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.Metric[0].SHA256))
 
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(a.Spec.Plugins.Metric[0].Name))
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(a.Spec.Plugins.Metric[0].Location))
 
 		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.TrafficManagement[0].Name))
 		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.TrafficManagement[0].Location))
+		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.TrafficManagement[0].SHA256))
 
 		By("Update metric and traffic plugins through RolloutManager CR")
 		updatedPluginLocation := "https://test-updated-plugin-location"
 
 		a.Spec.Plugins.TrafficManagement = []v1alpha1.Plugin{
-			{Name: "custom-traffic-plugin", Location: updatedPluginLocation},
+			{Name: "custom-traffic-plugin", Location: updatedPluginLocation, SHA256: "sha256-traffic-updated"},
 		}
 		a.Spec.Plugins.Metric = []v1alpha1.Plugin{
 			{Name: "custom-metric-plugin", Location: updatedPluginLocation, SHA256: "sha256-test"},
@@ -177,11 +179,13 @@ var _ = Describe("ConfigMap Test", func() {
 		By("Verify that ConfigMap is updated with the plugins modified by RolloutManger CR")
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.Metric[0].Name))
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(updatedPluginLocation))
+		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.Metric[0].SHA256))
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(a.Spec.Plugins.Metric[0].Name))
 		Expect(fetchedConfigMap.Data[MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(updatedPluginLocation))
 
 		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.TrafficManagement[0].Name))
 		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(updatedPluginLocation))
+		Expect(fetchedConfigMap.Data[TrafficRouterPluginConfigMapKey]).To(ContainSubstring(a.Spec.Plugins.TrafficManagement[0].SHA256))
 
 		By("Verify that OpenShiftRolloutPlugin is not updated through RolloutManager CR")
 		a.Spec.Plugins = v1alpha1.Plugins{

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -659,8 +659,10 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&configMap), &configMap)).To(Succeed())
 			Expect(configMap.Data[controllers.TrafficRouterPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.TrafficManagement[0].Name))
 			Expect(configMap.Data[controllers.TrafficRouterPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.TrafficManagement[0].Location))
+			Expect(configMap.Data[controllers.TrafficRouterPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.TrafficManagement[0].SHA256))
 			Expect(configMap.Data[controllers.MetricPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].Name))
 			Expect(configMap.Data[controllers.MetricPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].Location))
+			Expect(configMap.Data[controllers.MetricPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].SHA256))
 			Expect(configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].Name))
 			Expect(configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]).ToNot(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].Location))
 
@@ -685,8 +687,10 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 				}
 				return strings.Contains(configMap.Data[controllers.TrafficRouterPluginConfigMapKey], rolloutsManager.Spec.Plugins.TrafficManagement[0].Name) &&
 					strings.Contains(configMap.Data[controllers.TrafficRouterPluginConfigMapKey], rolloutsManager.Spec.Plugins.TrafficManagement[0].Location) &&
+					strings.Contains(configMap.Data[controllers.TrafficRouterPluginConfigMapKey], rolloutsManager.Spec.Plugins.TrafficManagement[0].SHA256) &&
 					strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Name) &&
 					strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Location) &&
+					strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].SHA256) &&
 					!strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey], rolloutsManager.Spec.Plugins.Metric[0].Name)
 
 			}, "1m", "1s").Should(BeTrue())
@@ -766,6 +770,7 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 				By("Verify metric plugin is under the new key and not the old key")
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&configMap), &configMap)).To(Succeed())
 				Expect(configMap.Data[controllers.MetricPluginConfigMapKey]).To(ContainSubstring("prometheus"))
+				Expect(configMap.Data[controllers.MetricPluginConfigMapKey]).To(ContainSubstring(rolloutsManager.Spec.Plugins.Metric[0].SHA256))
 				Expect(configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]).NotTo(ContainSubstring("prometheus"))
 
 				By("Manually inject data under the old invalid key into the ConfigMap")
@@ -795,7 +800,8 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 					_, oldKeyExists := configMap.Data[controllers.MetricPluginConfigMapKey_PreviousInvalidKey]
 					res := !oldKeyExists &&
 						strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], "prometheus") &&
-						strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Location)
+						strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].Location) &&
+						strings.Contains(configMap.Data[controllers.MetricPluginConfigMapKey], rolloutsManager.Spec.Plugins.Metric[0].SHA256)
 
 					if !res {
 						GinkgoWriter.Println("configMap:", configMap.Data)


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Traffic Management plugin SHA256 value (in RolloutManager CR)  was not being correctly inserted into `ConfigMap` which was passed to Rollouts
- This PR fixes the bug, and adds additional tests to catch that bad behaviour.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR, and has been updated.

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin integrity is now verified using SHA256 checksums for both traffic router and metric plugins
* **Bug Fixes**
  * Corrected error messages to properly reference ConfigMap failures instead of service account issues
* **Tests**
  * Plugin configuration tests now include and validate SHA256 checksum values for improved verification coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->