### PR TITLE
Upgrade to Argo Rollouts v1.9.1

### DIFF
--- a/controllers/default.go
+++ b/controllers/default.go
@@ -12,7 +12,7 @@ const (
 	DefaultArgoRolloutsImage = "quay.io/argoproj/argo-rollouts"
 
 	// ArgoRolloutsDefaultVersion is the default version for the Rollouts controller.
-	DefaultArgoRolloutsVersion = "v1.9.0" // v1.9.0
+	DefaultArgoRolloutsVersion = "v1.9.1" // v1.9.1
 
 	// DefaultArgoRolloutsResourceName is the default name for Rollouts controller resources such as
 	// deployment, service, role, rolebinding and serviceaccount.

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -360,19 +360,6 @@ func rolloutsContainer(cr rolloutsmanagerv1alpha1.RolloutManager) (corev1.Contai
 				Name:          "metrics",
 			},
 		},
-		ReadinessProbe: &corev1.Probe{
-			FailureThreshold: int32(5),
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/metrics",
-					Port: intstr.FromString("metrics"),
-				},
-			},
-			InitialDelaySeconds: int32(10),
-			PeriodSeconds:       int32(5),
-			SuccessThreshold:    int32(1),
-			TimeoutSeconds:      int32(4),
-		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{
@@ -495,7 +482,6 @@ func normalizeDeployment(inputParam appsv1.Deployment, cr rolloutsmanagerv1alpha
 	inputContainer := input.Spec.Template.Spec.Containers[0]
 	inputLivenessProbe := inputContainer.LivenessProbe
 	inputPorts := inputContainer.Ports
-	inputReadinessProbe := inputContainer.ReadinessProbe
 	inputSecurityContext := inputContainer.SecurityContext
 	inputVolumeMounts := inputContainer.VolumeMounts
 
@@ -505,14 +491,7 @@ func normalizeDeployment(inputParam appsv1.Deployment, cr rolloutsmanagerv1alpha
 
 	if inputLivenessProbe.ProbeHandler.HTTPGet == nil {
 		return appsv1.Deployment{}, fmt.Errorf("incorrect http get in liveness probe")
-	}
 
-	if inputReadinessProbe == nil {
-		return appsv1.Deployment{}, fmt.Errorf("incorrect readiness probe")
-	}
-
-	if inputReadinessProbe.ProbeHandler.HTTPGet == nil {
-		return appsv1.Deployment{}, fmt.Errorf("incorrect http get in readiness probe")
 	}
 
 	if inputPorts == nil || len(inputPorts) != 2 {
@@ -607,20 +586,8 @@ func normalizeDeployment(inputParam appsv1.Deployment, cr rolloutsmanagerv1alpha
 				Name:          inputPorts[1].Name,
 			},
 		},
-		ReadinessProbe: &corev1.Probe{
-			FailureThreshold: inputReadinessProbe.FailureThreshold,
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: inputReadinessProbe.ProbeHandler.HTTPGet.Path,
-					Port: inputReadinessProbe.ProbeHandler.HTTPGet.Port,
-				},
-			},
-			InitialDelaySeconds: inputReadinessProbe.InitialDelaySeconds,
-			PeriodSeconds:       inputReadinessProbe.PeriodSeconds,
-			SuccessThreshold:    inputReadinessProbe.SuccessThreshold,
-			TimeoutSeconds:      inputReadinessProbe.TimeoutSeconds,
-		},
-		Resources: inputContainer.Resources,
+		ReadinessProbe: inputContainer.ReadinessProbe,
+		Resources:      inputContainer.Resources,
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Drop: inputSecurityContext.Capabilities.Drop,

--- a/controllers/deployment_test.go
+++ b/controllers/deployment_test.go
@@ -650,14 +650,6 @@ var _ = Describe("normalizeDeployment tests to verify that an error is returned"
 			deployment.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet = nil
 		}, "incorrect http get in liveness probe"),
 
-		Entry("readiness probe is nil", func() {
-			deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = nil
-		}, "incorrect readiness probe"),
-
-		Entry("readiness probe http get is nil", func() {
-			deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet = nil
-		}, "incorrect http get in readiness probe"),
-
 		Entry("input ports is nil", func() {
 			deployment.Spec.Template.Spec.Containers[0].Ports = nil
 		}, "incorrect input ports"),

--- a/hack/run-upstream-argo-rollouts-e2e-tests.sh
+++ b/hack/run-upstream-argo-rollouts-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CURRENT_ROLLOUTS_VERSION=v1.9.0
+CURRENT_ROLLOUTS_VERSION=v1.9.1
 
 function cleanup {
   echo "* Cleaning up"
@@ -144,5 +144,6 @@ set -e
 "$SCRIPT_DIR/verify-rollouts-e2e-tests/verify-e2e-test-results.sh" /tmp/test-e2e.log
 
 echo "* SUCCESS: No unexpected errors occurred."
+
 
 

--- a/tests/e2e/rollout_tests_all.go
+++ b/tests/e2e/rollout_tests_all.go
@@ -26,6 +26,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
@@ -907,6 +908,46 @@ func RunRolloutsTests(namespaceScopedParam bool) {
 			})
 		})
 
+		When("A RolloutManager is created", func() {
+			It("should not have a readiness probe on the deployment, and should remove one if it already exists", func() {
+				By("creating a RolloutManager and waiting for it to be available")
+				Expect(k8sClient.Create(ctx, &rolloutManager)).To(Succeed())
+				Eventually(rolloutManager, "60s", "1s").Should(rolloutManagerFixture.HavePhase(rolloutsmanagerv1alpha1.PhaseAvailable))
+				deployment := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      controllers.DefaultArgoRolloutsResourceName,
+						Namespace: rolloutManager.Namespace,
+					},
+				}
+				Eventually(&deployment, "10s", "1s").Should(k8s.ExistByName(k8sClient))
+				By("verifying that the deployment does not have a readiness probe on new install")
+				Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
+				By("manually adding a readiness probe to the deployment to simulate an existing install")
+				err := k8s.UpdateWithoutConflict(ctx, &deployment, k8sClient, func(obj client.Object) {
+					depl, ok := obj.(*appsv1.Deployment)
+					Expect(ok).To(BeTrue())
+					depl.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
+						FailureThreshold: int32(5),
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/metrics",
+								Port: intstr.FromString("metrics"),
+							},
+						},
+						InitialDelaySeconds: int32(10),
+						PeriodSeconds:       int32(5),
+						SuccessThreshold:    int32(1),
+						TimeoutSeconds:      int32(4),
+					}
+				})
+				Expect(err).ToNot(HaveOccurred())
+				By("verifying that the operator removes the readiness probe on the next reconciliation")
+				Eventually(func() *corev1.Probe {
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment)).To(Succeed())
+					return deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+				}, "30s", "1s").Should(BeNil())
+			})
+		})
 		It("should contain two replicas and the '--leader-elect' argument set to true, and verify that the anti-affinity rule is added by default when HA is enabled", func() {
 			By("Create cluster-scoped RolloutManager in a namespace.")
 


### PR DESCRIPTION
Update to latest release of Argo Rollouts: https://github.com/argoproj/argo-rollouts/releases/tag/v1.9.1
Before merging this PR, ensure you check the Argo Rollouts change logs and release notes: 
- Ensure there are no changes to the Argo Rollouts install YAML that we need to respond to with changes in the operator
    - You can do this by downloading the 'install.yaml' from both the previous version (for example, v1.7.1) and new version (for example, v1.7.2), and then comparing them using a tool like [Meld](https://gitlab.gnome.org/GNOME/meld) or diff.
	- If there are changes to resources like Deployments and Roles in the install.yaml between the two versions, this will likely require a corresponding code change within the operator. e.g. a new permission added to a Role would require a change to the Role creation code in the operator.
- Ensure there are no backwards incompatible API/behaviour changes in the change logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployments no longer include the automatically configured readiness probe.
  - Existing readiness probes are removed during reconciliation, ensuring deployments match the expected configuration.
  - Added end-to-end coverage for readiness probe cleanup.

- **Bug Fixes**
  - Deployment processing now handles containers without readiness probes correctly.

- **Maintenance**
  - Updated the bundled Argo Rollouts version from 1.9.0 to 1.9.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->